### PR TITLE
ci: Update release token for push access to protected branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
             @semantic-release/git@10.0.1
             conventional-changelog-conventionalcommits@7.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
I've created a new personal access token under my username to allow the semantic-release-bot to push to a protected branch.

The repository secret, `RELEASE_TOKEN` has been added to this repository with the new token as the contents for this purpose.