### PR TITLE
fix: Add Makefile with hermetic local development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ override.tf.json
 terraform.rc
 debug/
 bin/
+cache/

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ override.tf.json
 terraform.rc
 debug/
 bin/
-cache/
+_*/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+PATH  := $(PWD)/bin:$(PATH)
+SHELL := env PATH=$(PATH) /bin/sh
+
+# Terraform
+version  ?= "1.7.1"
+os       ?= $(shell uname|tr A-Z a-z)
+ifeq ($(shell uname -m),x86_64)
+  arch   ?= "amd64"
+endif
+ifeq ($(shell uname -m),i686)
+  arch   ?= "386"
+endif
+ifeq ($(shell uname -m),aarch64)
+  arch   ?= "arm"
+endif
+ifeq ($(shell uname -m),arm64)
+  arch   ?= "arm64"
+endif
+
+pwd       := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+terraform := $(shell command -v $(pwd)/bin/terraform 2> /dev/null)
+
+ifndef terraform
+  install ?= "true"
+endif
+
+.PHONY: install
+install:
+ifeq ($(install),"true")
+	@curl --create-dirs --output-dir ./bin -O -L https://releases.hashicorp.com/terraform/$(version)/terraform_$(version)_$(os)_$(arch).zip
+	@unzip -d $(pwd)/bin $(pwd)/bin/terraform_$(version)_$(os)_$(arch).zip && rm ./bin/terraform_$(version)_$(os)_$(arch).zip
+endif
+	@terraform --version
+
+.PHONY: test clean all 
+
+all:
+	echo "Building..."
+
+clean:
+	@rm -rf $(pwd)/bin
+
+test:
+	echo "Testing..."

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,96 @@
-PATH  := $(PWD)/bin:$(PATH)
-SHELL := env PATH=$(PATH) /bin/sh
+BIN           := $(PWD)/_bin
+CACHE         := $(PWD)/_cache
+GOPATH        := $(CACHE)/go
+PATH          := $(BIN):$(PATH)
+SHELL         := env PATH=$(PATH) GOPATH=$(GOPATH) /bin/sh
+PROVIDER_NAME := terraform-provider-github
 
-# Terraform
-version  ?= "1.7.1"
 os       ?= $(shell uname|tr A-Z a-z)
 ifeq ($(shell uname -m),x86_64)
-  arch   ?= "amd64"
+  arch   ?= amd64
 endif
 ifeq ($(shell uname -m),i686)
-  arch   ?= "386"
+  arch   ?= 386
 endif
 ifeq ($(shell uname -m),aarch64)
-  arch   ?= "arm"
+  arch   ?= arm
 endif
 ifeq ($(shell uname -m),arm64)
-  arch   ?= "arm64"
+  arch   ?= arm64
 endif
 
-pwd       := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-terraform := $(shell command -v $(pwd)/bin/terraform 2> /dev/null)
+.PHONY: all
+all: format lint test build install
 
-ifndef terraform
-  install ?= "true"
-endif
+.PHONY: tools
+tools: $(BIN)/go $(BIN)/golangci-lint
+
+# Setup Go
+go_version      := 1.22.1
+go_package_name := go$(go_version).$(os)-$(arch)
+go_package_url  := https://go.dev/dl/$(go_package_name).tar.gz
+go_install_path := $(BIN)/go-$(go_version)-$(os)-$(arch)
+
+$(BIN)/go:
+	@mkdir -p $(BIN)
+	@mkdir -p $(GOPATH)
+	@echo "Downloading Go $(go_version) to $(go_install_path)..."
+	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(go_package_url)
+	@tar -C $(BIN) -xzf $(BIN)/$(go_package_name).tar.gz && rm $(BIN)/$(go_package_name).tar.gz
+	@mv $(BIN)/go $(go_install_path)
+	@ln -s $(go_install_path)/bin/go $(BIN)/go
+
+# Setup golangci
+golangci_version      := 1.57.1
+golangci_package_name := golangci-lint-$(golangci_version)-$(os)-$(arch)
+golangci_package_url  := https://github.com/golangci/golangci-lint/releases/download/v$(golangci_version)/$(golangci_package_name).tar.gz
+golangci_install_path := $(BIN)/$(golangci_package_name)
+
+$(BIN)/golangci-lint:
+	@mkdir -p $(BIN)
+	@echo "Downloading golangci-lint $(golangci_version) to $(BIN)/golangci-lint-$(golangci_version)..."
+	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(golangci_package_url)
+	@tar -C $(BIN) -xzf $(BIN)/$(golangci_package_name).tar.gz && rm $(BIN)/$(golangci_package_name).tar.gz
+	@ln -s $(golangci_install_path)/golangci-lint $(BIN)/golangci-lint
+
+.PHONY: update
+update: $(BIN)/go
+	@echo "Updating dependencies..."
+	@go get -u
+	@go mod tidy
+
+.PHONY: build
+build: $(BIN)/$(PROVIDER_NAME)
+
+$(BIN)/$(PROVIDER_NAME): update
+	@echo "Building..."
+	@go build -o $(BIN)
 
 .PHONY: install
-install:
-ifeq ($(install),"true")
-	@curl --create-dirs --output-dir ./bin -O -L https://releases.hashicorp.com/terraform/$(version)/terraform_$(version)_$(os)_$(arch).zip
-	@unzip -d $(pwd)/bin $(pwd)/bin/terraform_$(version)_$(os)_$(arch).zip && rm ./bin/terraform_$(version)_$(os)_$(arch).zip
-endif
-	@terraform --version
+install: $(CACHE)/bin/$(PROVIDER_NAME)
 
-.PHONY: test clean all 
+$(CACHE)/bin/$(PROVIDER_NAME): update
+	@echo "Installing..."
+	@go install ./...
 
-all:
-	echo "Building..."
+.PHONY: format
+format: $(BIN)/go
+	@echo "Formatting..."
+	@go fmt ./...
 
+.PHONY: lint
+lint: tools
+	@echo "Linting..."
+	@golangci-lint run ./...
+
+.PHONY: test
+test: $(BIN)/go
+	@echo "Testing..."
+
+.PHONY: clean
 clean:
-	@rm -rf $(pwd)/bin
-
-test:
-	echo "Testing..."
+	@echo "Removing the $(CACHE) directory..."
+	@go clean -modcache
+	@rm -rf $(CACHE)
+	@echo "Removing the $(BIN) directory..."
+	@rm -rf $(BIN)


### PR DESCRIPTION
Setup a hermetic local build environment with the introduction of a `Makefile`. The goal is to streamline the development process by ensuring that all developers, regardless of their setup, can clone the repository and immediately run make commands to `format`, `lint`, `build`, `install`, and `test` without needing to manually configure their local environment. 

This is achieved by automating the installation of all necessary tools and dependencies directly into isolated directories within the project.

The `make clean` command removes everything that was installed as part of the other targets.