### PR TITLE
chore: Update local builds to use `.local/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ override.tf.json
 terraform.rc
 debug/
 bin/
-_*/
+.local/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BIN           := $(PWD)/_bin
-CACHE         := $(PWD)/_cache
+BIN           := $(PWD)/.local/bin
+CACHE         := $(PWD)/.local/cache
 GOPATH        := $(CACHE)/go
 PATH          := $(BIN):$(PATH)
 SHELL         := env PATH=$(PATH) GOPATH=$(GOPATH) /bin/sh


### PR DESCRIPTION
Moves local builds from `_bin/` and `_cache/` to `.local/bin` and `.local/cache`.