### PR TITLE
chore: Update release process configuration for conventional commits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,11 +46,29 @@ changelog:
     - title: Bug Fixes
       regexp: ^.*?fix(\([[:word:]]+\))??!?:.+$
       order: 1
+    - title: Performance
+      regexp: ^.*?perf(\([[:word:]]+\))??!?:.+$
+      order: 2
+    - title: Reverts
+      regexp: ^.*?revert(\([[:word:]]+\))??!?:.+$
+      order: 3
     - title: Documentation
       regexp: ^.*?docs(\([[:word:]]+\))??!?:.+$
-      order: 2
+      order: 4
+    - title: Style
+      regexp: ^.*?style(\([[:word:]]+\))??!?:.+$
+      order: 5
+    - title: Tests
+      regexp: ^.*?test(\([[:word:]]+\))??!?:.+$
+      order: 6
+    - title: Build
+      regexp: ^.*?build(\([[:word:]]+\))??!?:.+$
+      order: 7
     - title: CI
       regexp: ^.*?ci(\([[:word:]]+\))??!?:.+$
-      order: 3
+      order: 8
+    - title: Chores
+      regexp: ^.*?chore(\([[:word:]]+\))??!?:.+$
+      order: 9
     - title: Others
       order: 999

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -7,12 +7,29 @@ plugins:
   - - '@semantic-release/commit-analyzer'
     - preset: conventionalCommits
       releaseRules:
+        - type: feat
+          release: minor
+        - type: fix
+          release: patch
+        - type: perf
+          release: patch
+        - type: revert
+          release: patch
         - type: docs
           release: patch
+        - type: style
+          release: false
+        - type: test
+          release: false
+        - type: build
+          release: false
         - type: ci
+          release: false
+        - type: chore
+          release: false
+        - type: chore
+          scope: deps
           release: patch
-        - type: major
-          release: major
   - '@semantic-release/git'
 
 preset: conventionalcommits


### PR DESCRIPTION
Update release configuration to include more conventional commit prefixes.