### PR TITLE
chore: Update goreleaser configuration to version 2 and fix deprecated format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - env:
       - CGO_ENABLED=0
@@ -15,7 +16,7 @@ builds:
       - arm64
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-  - format: zip
+  - formats: [zip]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
Update goreleaser configuration to version 2 and fix deprecated format.