### PR TITLE
chore: Add actionlint for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PROVIDER_NAME := terraform-provider-github
 go_version           := 1.25.0
 golangci_version     := 2.4.0
 tfplugindocs_version := 0.20.1
+actionlint_version   := 1.7.7
 
 # Operating System and Architecture
 os ?= $(shell uname|tr A-Z a-z)
@@ -24,7 +25,7 @@ endif
 all: format lint install docs test
 
 .PHONY: tools
-tools: $(BIN)/go $(BIN)/golangci-lint $(GOPATH)/bin/tfplugindocs
+tools: $(BIN)/go $(BIN)/golangci-lint $(GOPATH)/bin/tfplugindocs $(BIN)/actionlint
 
 # Setup Go
 go_package_name := go$(go_version).$(os)-$(arch)
@@ -56,6 +57,19 @@ $(BIN)/golangci-lint:
 $(GOPATH)/bin/tfplugindocs: $(BIN)/go
 	@go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v$(tfplugindocs_version)
 
+# Setup actionlint
+actionlint_package_name := actionlint_$(actionlint_version)_$(os)_$(arch)
+actionlint_package_url  := https://github.com/rhysd/actionlint/releases/download/v$(actionlint_version)/$(actionlint_package_name).tar.gz
+actionlint_install_path := $(BIN)/$(actionlint_package_name)
+
+$(BIN)/actionlint:
+	@mkdir -p $(BIN)
+	@echo "Downloading actionlint $(actionlint_version) to $(BIN)/actionlint-$(actionlint_version)..."
+	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(actionlint_package_url)
+	@mkdir -p $(actionlint_install_path) # actionlint isn't packaged in a directory
+	@tar -C $(actionlint_install_path) -xzf $(BIN)/$(actionlint_package_name).tar.gz && rm $(BIN)/$(actionlint_package_name).tar.gz
+	@ln -s $(actionlint_install_path)/actionlint $(BIN)/actionlint
+
 .PHONY: update
 update: $(BIN)/go
 	@echo "Updating dependencies..."
@@ -81,6 +95,7 @@ format: tools
 lint: tools update
 	@echo "Linting..."
 	@golangci-lint run ./...
+	@actionlint .github/workflows/*.yml
 
 .PHONY: docs
 docs: tools update install
@@ -99,3 +114,5 @@ clean:
 	@rm -rf $(CACHE)
 	@echo "Removing the $(BIN) directory..."
 	@rm -rf $(BIN)
+	@echo "Removing the $(PWD)/.local directory..."
+	@rmdir $(PWD)/.local


### PR DESCRIPTION
This adds actionlint to the local development toolchain for linting GitHub Actions workflows.