### PR TITLE
ci: Automate tooling and dependency updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
-on:
-  - pull_request
+on: pull_request
 
 jobs:
   actionlint:
@@ -30,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.14.0
+          python-version: 3.14.3
       - name: Install yamllint
         run: |
           pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,4 +81,9 @@ jobs:
           cache: true
       - name: Validate Docs
         run: |-
-          echo "Validate the docs have been generated."
+          make docs
+
+          if ! git diff --exit-code; then
+            printf '%s\n' "Documentation is out of date. Run 'make docs' and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,8 +53,8 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.10.1
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-cache: true
+          skip-save-cache: true
   terraform-fmt:
     name: Terraform
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,84 +1,84 @@
 name: Lint
 
 on:
-- pull_request
+  - pull_request
 
 jobs:
   actionlint:
     name: GitHub Actions
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version: 1.26.0
-        cache: false
-    - name: Install actionlint
-      run: |
-        go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
-    - name: Lint Workflow Files
-      run: |
-        actionlint -color
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.26.0
+          cache: false
+      - name: Install actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+      - name: Lint Workflow Files
+        run: |
+          actionlint -color
   yamllint:
     name: YAML
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: 3.14.0
-    - name: Install yamllint
-      run: |
-        pip install --upgrade pip
-        pip install yamllint
-    - name: Lint YAML Files
-      run: |
-        yamllint .
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.14.0
+      - name: Install yamllint
+        run: |
+          pip install --upgrade pip
+          pip install yamllint
+      - name: Lint YAML Files
+        run: |
+          yamllint .
   golangci-lint:
     name: Go
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Lint Go Files
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-      with:
-        version: v2.10.1
-        skip-pkg-cache: true
-        skip-build-cache: true
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Lint Go Files
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.10.1
+          skip-pkg-cache: true
+          skip-build-cache: true
   terraform-fmt:
     name: Terraform
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      with:
-        terraform_version: 1.14.0
-    - name: Lint Terraform Files
-      run: |
-        terraform fmt -recursive -check
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: 1.14.0
+      - name: Lint Terraform Files
+        run: |
+          terraform fmt -recursive -check
   tfplugindocs:
     name: Docs
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Validate Docs
-      run: |-
-        echo "Validate the docs have been generated."
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Validate Docs
+        run: |-
+          echo "Validate the docs have been generated."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           pip install yamllint
       - name: Lint YAML Files
         run: |
-          yamllint .
+          yamllint --strict .github/workflows
   golangci-lint:
     name: Go
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,6 +83,6 @@ jobs:
           make docs
 
           if ! git diff --exit-code; then
-            printf '%s\n' "Documentation is out of date. Run 'make docs' and commit the changes."
+            echo "::error title=Docs::Documentation is out of date. Run 'make docs' and commit the changes."
             exit 1
           fi

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,9 +3,9 @@ name: Pre-release
 on:
   pull_request_target:
     types:
-    - opened
-    - edited
-    - synchronize
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: read
@@ -15,8 +15,8 @@ jobs:
     name: Semantic Title
     runs-on: ubuntu-22.04
     steps:
-    - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
-      with:
-        requireScope: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
+        with:
+          requireScope: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-    - main
+      - main
 
 permissions:
   contents: write
@@ -15,18 +15,18 @@ jobs:
     name: Tag Release
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Release
-      uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
-      id: release
-      with:
-        semantic_version: 25.0.2
-        extra_plugins: |
-          @semantic-release/git@10.0.1
-          conventional-changelog-conventionalcommits@9.1.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Release
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
+        id: release
+        with:
+          semantic_version: 25.0.2
+          extra_plugins: |
+            @semantic-release/git@10.0.1
+            conventional-changelog-conventionalcommits@9.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     outputs:
       new_release_published: ${{ steps.release.outputs.new_release_published }}
   goreleaser:
@@ -35,25 +35,25 @@ jobs:
     if: needs.release.outputs.new_release_published == 'true'
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
-    - name: Setup Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
-      id: import_gpg
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-      with:
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,138 +15,271 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  dependencies-and-tooling:
-    name: Dependencies and Tooling
+  check-open-pr:
+    name: Check Existing PR
     runs-on: ubuntu-24.04
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+      branch_name: ${{ steps.check.outputs.branch_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for an Existing Pull Request
-        id: check-open-pull-requests
+        id: check
         run: |
           BRANCH_NAME="update/dependencies-and-tooling"
-          if gh pr list --head "$BRANCH_NAME" --state open --json number | jq -e '. | length > 0' >/dev/null; then
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+
+          if gh pr list --head "$BRANCH_NAME" --state open --json number \
+            | jq -e '. | length > 0' >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Create Branch and Update Dependencies/Tooling
-        id: update
-        if: steps.check-open-pull-requests.outputs.exists == 'false'
+
+  discover-go-version:
+    name: Discover Go
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      go_version: ${{ steps.discover.outputs.go_version }}
+    steps:
+      - name: Discover Latest Stable Go Version
+        id: discover
         run: |
-          set -euo pipefail
+          GO_VERSION="$(curl --silent --show-error --fail 'https://go.dev/dl/?mode=json' \
+            | jq -r '[.[] | select(.stable == true)][0].version | sub("^go"; "")')"
+          echo "go_version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
-          latest_release_tag() {
-            local repo="$1"
-            curl --silent --show-error --fail \
-              --header "Accept: application/vnd.github+json" \
-              --header "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/${repo}/releases/latest" \
-            | jq -r '.tag_name'
-          }
+  discover-python-version:
+    name: Discover Python
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      python_version: ${{ steps.discover.outputs.python_version }}
+    steps:
+      - name: Discover Latest Stable Python Version
+        id: discover
+        run: |
+          PYTHON_TAG="$(gh api repos/python/cpython/releases/latest --jq .tag_name)"
+          echo "python_version=${PYTHON_TAG#v}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-          latest_stable_go_version() {
-            curl --silent --show-error --fail "https://go.dev/dl/?mode=json" \
-            | jq -r '[.[] | select(.stable == true)][0].version | sub("^go"; "")'
-          }
+  discover-golangci:
+    name: Discover golangci-lint
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      golangci_tag: ${{ steps.discover.outputs.golangci_tag }}
+      golangci_version: ${{ steps.discover.outputs.golangci_version }}
+    steps:
+      - name: Discover Latest golangci-lint Tag
+        id: discover
+        run: |
+          TAG="$(gh api repos/golangci/golangci-lint/releases/latest --jq .tag_name)"
+          {
+            echo "golangci_tag=${TAG}"
+            echo "golangci_version=${TAG#v}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-          # Discover latest versions.
-          GO_VERSION="$(latest_stable_go_version)"
-          GOLANGCI_TAG="$(latest_release_tag "golangci/golangci-lint")"
-          TFPLUGINDOCS_TAG="$(latest_release_tag "hashicorp/terraform-plugin-docs")"
-          ACTIONLINT_TAG="$(latest_release_tag "rhysd/actionlint")"
-          SHELLCHECK_TAG="$(latest_release_tag "koalaman/shellcheck")"
+  discover-tfplugindocs:
+    name: Discover tfplugindocs
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      tfplugindocs_tag: ${{ steps.discover.outputs.tfplugindocs_tag }}
+      tfplugindocs_version: ${{ steps.discover.outputs.tfplugindocs_version }}
+    steps:
+      - name: Discover Latest tfplugindocs Tag
+        id: discover
+        run: |
+          TAG="$(gh api repos/hashicorp/terraform-plugin-docs/releases/latest --jq .tag_name)"
+          {
+            echo "tfplugindocs_tag=${TAG}"
+            echo "tfplugindocs_version=${TAG#v}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-          GOLANGCI_VERSION="${GOLANGCI_TAG#v}"
-          TFPLUGINDOCS_VERSION="${TFPLUGINDOCS_TAG#v}"
-          ACTIONLINT_VERSION="${ACTIONLINT_TAG#v}"
-          SHELLCHECK_VERSION="${SHELLCHECK_TAG#v}"
+  discover-actionlint:
+    name: Discover actionlint
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      actionlint_tag: ${{ steps.discover.outputs.actionlint_tag }}
+      actionlint_version: ${{ steps.discover.outputs.actionlint_version }}
+      actionlint_sha: ${{ steps.discover.outputs.actionlint_sha }}
+    steps:
+      - name: Discover Latest actionlint Tag and SHA
+        id: discover
+        run: |
+          TAG="$(gh api repos/rhysd/actionlint/releases/latest --jq .tag_name)"
 
-          # Resolve the immutable commit SHA for the actionlint release tag.
-          ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}^{}" | awk '{print $1}')"
-          if [ -z "${ACTIONLINT_SHA}" ]; then
-            ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}" | awk '{print $1}')"
+          SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${TAG}^{}" \
+            | awk '{print $1}')"
+          if [ -z "${SHA}" ]; then
+            SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${TAG}" \
+              | awk '{print $1}')"
           fi
 
-          if [ -z "${ACTIONLINT_SHA}" ]; then
-            echo "Failed to resolve SHA for actionlint tag ${ACTIONLINT_TAG}."
+          if [ -z "${SHA}" ]; then
+            echo "Failed to resolve SHA for actionlint tag ${TAG}."
             exit 1
           fi
+
+          {
+            echo "actionlint_tag=${TAG}"
+            echo "actionlint_version=${TAG#v}"
+            echo "actionlint_sha=${SHA}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  discover-shellcheck:
+    name: Discover shellcheck
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      shellcheck_tag: ${{ steps.discover.outputs.shellcheck_tag }}
+      shellcheck_version: ${{ steps.discover.outputs.shellcheck_version }}
+    steps:
+      - name: Discover Latest shellcheck Tag
+        id: discover
+        run: |
+          TAG="$(gh api repos/koalaman/shellcheck/releases/latest --jq .tag_name)"
+          {
+            echo "shellcheck_tag=${TAG}"
+            echo "shellcheck_version=${TAG#v}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  apply-and-validate:
+    name: Apply Updates and Validate
+    runs-on: ubuntu-24.04
+    needs:
+      - check-open-pr
+      - discover-go-version
+      - discover-python-version
+      - discover-golangci
+      - discover-tfplugindocs
+      - discover-actionlint
+      - discover-shellcheck
+    if: needs.check-open-pr.outputs.exists == 'false'
+    outputs:
+      updated: ${{ steps.apply.outputs.updated }}
+      branch_name: ${{ steps.apply.outputs.branch_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Apply Updates and Validate
+        id: apply
+        env:
+          BRANCH_NAME: ${{ needs.check-open-pr.outputs.branch_name }}
+          GO_VERSION: ${{ needs.discover-go-version.outputs.go_version }}
+          PYTHON_VERSION: ${{ needs.discover-python-version.outputs.python_version }}
+          GOLANGCI_TAG: ${{ needs.discover-golangci.outputs.golangci_tag }}
+          GOLANGCI_VERSION: ${{ needs.discover-golangci.outputs.golangci_version }}
+          TFPLUGINDOCS_VERSION: ${{ needs.discover-tfplugindocs.outputs.tfplugindocs_version }}
+          ACTIONLINT_TAG: ${{ needs.discover-actionlint.outputs.actionlint_tag }}
+          ACTIONLINT_VERSION: ${{ needs.discover-actionlint.outputs.actionlint_version }}
+          ACTIONLINT_SHA: ${{ needs.discover-actionlint.outputs.actionlint_sha }}
+          SHELLCHECK_VERSION: ${{ needs.discover-shellcheck.outputs.shellcheck_version }}
+        run: |
+          set -euo pipefail
 
           git config --global user.name "craigsloggett"
           git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
-          BRANCH_NAME="update/dependencies-and-tooling"
-          git checkout -B "$BRANCH_NAME"
+          git checkout -B "${BRANCH_NAME}"
 
-          # Update local tool versions.
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+
           sed -i "s/^go_version[[:space:]]*:= .*/go_version           := ${GO_VERSION}/" Makefile
-          sed -i "s/^golangci_version[[:space:]]*:= .*/golangci_version     := ${GOLANGCI_VERSION}/" Makefile
-          sed -i "s/^tfplugindocs_version[[:space:]]*:= .*/tfplugindocs_version := ${TFPLUGINDOCS_VERSION}/" Makefile
-          sed -i "s/^actionlint_version[[:space:]]*:= .*/actionlint_version   := ${ACTIONLINT_VERSION}/" Makefile
-          sed -i "s/^shellcheck_version[[:space:]]*:= .*/shellcheck_version   := ${SHELLCHECK_VERSION}/" Makefile
+          sed -i "s/^golangci_version[[:space:]]*:= .*/golangci_version     := ${GOLANGCI_VERSION}/" \
+            Makefile
+          sed -i "s/^tfplugindocs_version[[:space:]]*:= .*/tfplugindocs_version := ${TFPLUGINDOCS_VERSION}/" \
+            Makefile
+          sed -i "s/^actionlint_version[[:space:]]*:= .*/actionlint_version   := ${ACTIONLINT_VERSION}/" \
+            Makefile
+          sed -i "s/^shellcheck_version[[:space:]]*:= .*/shellcheck_version   := ${SHELLCHECK_VERSION}/" \
+            Makefile
 
-          # Keep go.mod and CI aligned with the configured Go/tooling versions.
           sed -i "s/^go .*/go ${GO_VERSION}/" go.mod
           sed -i "s/^\([[:space:]]*go-version: \).*/\1${GO_VERSION}/" .github/workflows/lint.yml
-          sed -i "s|^\([[:space:]]*go install github.com/rhysd/actionlint/cmd/actionlint@\).*|\1${ACTIONLINT_SHA} # ${ACTIONLINT_TAG}|" .github/workflows/lint.yml
+          sed -i "s/^\([[:space:]]*python-version: \).*/\1${PYTHON_VERSION}/" .github/workflows/lint.yml
+
+          ACTIONLINT_PATTERN='^\([[:space:]]*go install github.com/rhysd/actionlint/cmd/actionlint@\).*'
+          sed -i "s|${ACTIONLINT_PATTERN}|\1${ACTIONLINT_SHA} # ${ACTIONLINT_TAG}|" .github/workflows/lint.yml
           sed -i "s/^\([[:space:]]*version: \).*/\1${GOLANGCI_TAG}/" .github/workflows/lint.yml
 
-          # Refresh provider dependencies and validate.
           make clean
           make update
           make
 
           if git diff --quiet; then
             echo "No updates available."
-            {
-              echo "updated=false"
-            } >> "$GITHUB_OUTPUT"
+            echo "updated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git add Makefile go.mod go.sum .github/workflows/lint.yml
           git commit -m "chore(deps): update tooling and dependencies"
+          git push --force-with-lease origin "${BRANCH_NAME}"
 
-          git push --force-with-lease origin "$BRANCH_NAME"
+          echo "updated=true" >> "$GITHUB_OUTPUT"
 
-          {
-            echo "updated=true"
-            echo "branch_name=${BRANCH_NAME}"
-            echo "go_version=${GO_VERSION}"
-            echo "golangci_tag=${GOLANGCI_TAG}"
-            echo "tfplugindocs_tag=${TFPLUGINDOCS_TAG}"
-            echo "actionlint_tag=${ACTIONLINT_TAG}"
-            echo "shellcheck_tag=${SHELLCHECK_TAG}"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
+  create-pr:
+    name: Create Pull Request
+    runs-on: ubuntu-24.04
+    needs:
+      - apply-and-validate
+      - discover-go-version
+      - discover-python-version
+      - discover-golangci
+      - discover-tfplugindocs
+      - discover-actionlint
+      - discover-shellcheck
+    if: needs.apply-and-validate.outputs.updated == 'true'
+    steps:
       - name: Create Pull Request
-        if: steps.check-open-pull-requests.outputs.exists == 'false' && steps.update.outputs.updated == 'true'
         run: |
           gh pr create \
             --title "chore(deps): update tooling and dependencies" \
             --body "$(cat <<'EOF'
-          This PR was created automatically by the scheduled `update` workflow.
+          This PR was created automatically by the scheduled \`update\` workflow.
 
           Updated versions:
-          - Go: `${{ steps.update.outputs.go_version }}`
-          - golangci-lint: `${{ steps.update.outputs.golangci_tag }}`
-          - terraform-plugin-docs: `${{ steps.update.outputs.tfplugindocs_tag }}`
-          - actionlint: `${{ steps.update.outputs.actionlint_tag }}`
-          - shellcheck: `${{ steps.update.outputs.shellcheck_tag }}`
+          - Go: \`${{ needs.discover-go-version.outputs.go_version }}\`
+          - Python: \`${{ needs.discover-python-version.outputs.python_version }}\`
+          - golangci-lint: \`${{ needs.discover-golangci.outputs.golangci_tag }}\`
+          - terraform-plugin-docs: \`${{ needs.discover-tfplugindocs.outputs.tfplugindocs_tag }}\`
+          - actionlint: \`${{ needs.discover-actionlint.outputs.actionlint_tag }}\`
+          - shellcheck: \`${{ needs.discover-shellcheck.outputs.shellcheck_tag }}\`
 
           Included actions:
           - Updated Makefile tooling pins
-          - Updated CI pins in `.github/workflows/lint.yml`
-          - Ran `make update` to refresh Go dependencies
-          - Ran `make` to validate lint/test/build
+          - Updated CI pins in \`.github/workflows/lint.yml\`
+          - Ran \`make update\` to refresh Go dependencies
+          - Ran \`make\` to validate lint/test/build
           EOF
           )" \
             --base main \
-            --head "${{ steps.update.outputs.branch_name }}"
+            --head "${{ needs.apply-and-validate.outputs.branch_name }}"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,134 +19,134 @@ jobs:
     name: Dependencies and Tooling
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Check for an Existing Pull Request
-      id: check-open-pull-requests
-      run: |
-        BRANCH_NAME="update/dependencies-and-tooling"
-        if gh pr list --head "$BRANCH_NAME" --state open --json number | jq -e '. | length > 0' >/dev/null; then
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-        fi
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-    - name: Create Branch and Update Dependencies/Tooling
-      id: update
-      if: steps.check-open-pull-requests.outputs.exists == 'false'
-      run: |
-        set -euo pipefail
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check for an Existing Pull Request
+        id: check-open-pull-requests
+        run: |
+          BRANCH_NAME="update/dependencies-and-tooling"
+          if gh pr list --head "$BRANCH_NAME" --state open --json number | jq -e '. | length > 0' >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Create Branch and Update Dependencies/Tooling
+        id: update
+        if: steps.check-open-pull-requests.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
 
-        latest_release_tag() {
-          local repo="$1"
-          curl --silent --show-error --fail \
-            --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/${repo}/releases/latest" \
-          | jq -r '.tag_name'
-        }
+          latest_release_tag() {
+            local repo="$1"
+            curl --silent --show-error --fail \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              "https://api.github.com/repos/${repo}/releases/latest" \
+            | jq -r '.tag_name'
+          }
 
-        latest_stable_go_version() {
-          curl --silent --show-error --fail "https://go.dev/dl/?mode=json" \
-          | jq -r '[.[] | select(.stable == true)][0].version | sub("^go"; "")'
-        }
+          latest_stable_go_version() {
+            curl --silent --show-error --fail "https://go.dev/dl/?mode=json" \
+            | jq -r '[.[] | select(.stable == true)][0].version | sub("^go"; "")'
+          }
 
-        # Discover latest versions.
-        GO_VERSION="$(latest_stable_go_version)"
-        GOLANGCI_TAG="$(latest_release_tag "golangci/golangci-lint")"
-        TFPLUGINDOCS_TAG="$(latest_release_tag "hashicorp/terraform-plugin-docs")"
-        ACTIONLINT_TAG="$(latest_release_tag "rhysd/actionlint")"
-        SHELLCHECK_TAG="$(latest_release_tag "koalaman/shellcheck")"
+          # Discover latest versions.
+          GO_VERSION="$(latest_stable_go_version)"
+          GOLANGCI_TAG="$(latest_release_tag "golangci/golangci-lint")"
+          TFPLUGINDOCS_TAG="$(latest_release_tag "hashicorp/terraform-plugin-docs")"
+          ACTIONLINT_TAG="$(latest_release_tag "rhysd/actionlint")"
+          SHELLCHECK_TAG="$(latest_release_tag "koalaman/shellcheck")"
 
-        GOLANGCI_VERSION="${GOLANGCI_TAG#v}"
-        TFPLUGINDOCS_VERSION="${TFPLUGINDOCS_TAG#v}"
-        ACTIONLINT_VERSION="${ACTIONLINT_TAG#v}"
-        SHELLCHECK_VERSION="${SHELLCHECK_TAG#v}"
+          GOLANGCI_VERSION="${GOLANGCI_TAG#v}"
+          TFPLUGINDOCS_VERSION="${TFPLUGINDOCS_TAG#v}"
+          ACTIONLINT_VERSION="${ACTIONLINT_TAG#v}"
+          SHELLCHECK_VERSION="${SHELLCHECK_TAG#v}"
 
-        # Resolve the immutable commit SHA for the actionlint release tag.
-        ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}^{}" | awk '{print $1}')"
-        if [ -z "${ACTIONLINT_SHA}" ]; then
-          ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}" | awk '{print $1}')"
-        fi
+          # Resolve the immutable commit SHA for the actionlint release tag.
+          ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}^{}" | awk '{print $1}')"
+          if [ -z "${ACTIONLINT_SHA}" ]; then
+            ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}" | awk '{print $1}')"
+          fi
 
-        if [ -z "${ACTIONLINT_SHA}" ]; then
-          echo "Failed to resolve SHA for actionlint tag ${ACTIONLINT_TAG}."
-          exit 1
-        fi
+          if [ -z "${ACTIONLINT_SHA}" ]; then
+            echo "Failed to resolve SHA for actionlint tag ${ACTIONLINT_TAG}."
+            exit 1
+          fi
 
-        git config --global user.name "craigsloggett"
-        git config --global user.email "684196+craigsloggett@users.noreply.github.com"
+          git config --global user.name "craigsloggett"
+          git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
-        BRANCH_NAME="update/dependencies-and-tooling"
-        git checkout -B "$BRANCH_NAME"
+          BRANCH_NAME="update/dependencies-and-tooling"
+          git checkout -B "$BRANCH_NAME"
 
-        # Update local tool versions.
-        sed -i "s/^go_version[[:space:]]*:= .*/go_version           := ${GO_VERSION}/" Makefile
-        sed -i "s/^golangci_version[[:space:]]*:= .*/golangci_version     := ${GOLANGCI_VERSION}/" Makefile
-        sed -i "s/^tfplugindocs_version[[:space:]]*:= .*/tfplugindocs_version := ${TFPLUGINDOCS_VERSION}/" Makefile
-        sed -i "s/^actionlint_version[[:space:]]*:= .*/actionlint_version   := ${ACTIONLINT_VERSION}/" Makefile
-        sed -i "s/^shellcheck_version[[:space:]]*:= .*/shellcheck_version   := ${SHELLCHECK_VERSION}/" Makefile
+          # Update local tool versions.
+          sed -i "s/^go_version[[:space:]]*:= .*/go_version           := ${GO_VERSION}/" Makefile
+          sed -i "s/^golangci_version[[:space:]]*:= .*/golangci_version     := ${GOLANGCI_VERSION}/" Makefile
+          sed -i "s/^tfplugindocs_version[[:space:]]*:= .*/tfplugindocs_version := ${TFPLUGINDOCS_VERSION}/" Makefile
+          sed -i "s/^actionlint_version[[:space:]]*:= .*/actionlint_version   := ${ACTIONLINT_VERSION}/" Makefile
+          sed -i "s/^shellcheck_version[[:space:]]*:= .*/shellcheck_version   := ${SHELLCHECK_VERSION}/" Makefile
 
-        # Keep go.mod and CI aligned with the configured Go/tooling versions.
-        sed -i "s/^go .*/go ${GO_VERSION}/" go.mod
-        sed -i "s/^\([[:space:]]*go-version: \).*/\1${GO_VERSION}/" .github/workflows/lint.yml
-        sed -i "s|^\([[:space:]]*go install github.com/rhysd/actionlint/cmd/actionlint@\).*|\1${ACTIONLINT_SHA} # ${ACTIONLINT_TAG}|" .github/workflows/lint.yml
-        sed -i "s/^\([[:space:]]*version: \).*/\1${GOLANGCI_TAG}/" .github/workflows/lint.yml
+          # Keep go.mod and CI aligned with the configured Go/tooling versions.
+          sed -i "s/^go .*/go ${GO_VERSION}/" go.mod
+          sed -i "s/^\([[:space:]]*go-version: \).*/\1${GO_VERSION}/" .github/workflows/lint.yml
+          sed -i "s|^\([[:space:]]*go install github.com/rhysd/actionlint/cmd/actionlint@\).*|\1${ACTIONLINT_SHA} # ${ACTIONLINT_TAG}|" .github/workflows/lint.yml
+          sed -i "s/^\([[:space:]]*version: \).*/\1${GOLANGCI_TAG}/" .github/workflows/lint.yml
 
-        # Refresh provider dependencies and validate.
-        make clean
-        make update
-        make
+          # Refresh provider dependencies and validate.
+          make clean
+          make update
+          make
 
-        if git diff --quiet; then
-          echo "No updates available."
+          if git diff --quiet; then
+            echo "No updates available."
+            {
+              echo "updated=false"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git add Makefile go.mod go.sum .github/workflows/lint.yml
+          git commit -m "chore(deps): update tooling and dependencies"
+
+          git push --force-with-lease origin "$BRANCH_NAME"
+
           {
-            echo "updated=false"
+            echo "updated=true"
+            echo "branch_name=${BRANCH_NAME}"
+            echo "go_version=${GO_VERSION}"
+            echo "golangci_tag=${GOLANGCI_TAG}"
+            echo "tfplugindocs_tag=${TFPLUGINDOCS_TAG}"
+            echo "actionlint_tag=${ACTIONLINT_TAG}"
+            echo "shellcheck_tag=${SHELLCHECK_TAG}"
           } >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-        git add Makefile go.mod go.sum .github/workflows/lint.yml
-        git commit -m "chore(deps): update tooling and dependencies"
+      - name: Create Pull Request
+        if: steps.check-open-pull-requests.outputs.exists == 'false' && steps.update.outputs.updated == 'true'
+        run: |
+          gh pr create \
+            --title "chore(deps): update tooling and dependencies" \
+            --body "$(cat <<'EOF'
+          This PR was created automatically by the scheduled `update` workflow.
 
-        git push --force-with-lease origin "$BRANCH_NAME"
+          Updated versions:
+          - Go: `${{ steps.update.outputs.go_version }}`
+          - golangci-lint: `${{ steps.update.outputs.golangci_tag }}`
+          - terraform-plugin-docs: `${{ steps.update.outputs.tfplugindocs_tag }}`
+          - actionlint: `${{ steps.update.outputs.actionlint_tag }}`
+          - shellcheck: `${{ steps.update.outputs.shellcheck_tag }}`
 
-        {
-          echo "updated=true"
-          echo "branch_name=${BRANCH_NAME}"
-          echo "go_version=${GO_VERSION}"
-          echo "golangci_tag=${GOLANGCI_TAG}"
-          echo "tfplugindocs_tag=${TFPLUGINDOCS_TAG}"
-          echo "actionlint_tag=${ACTIONLINT_TAG}"
-          echo "shellcheck_tag=${SHELLCHECK_TAG}"
-        } >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-    - name: Create Pull Request
-      if: steps.check-open-pull-requests.outputs.exists == 'false' && steps.update.outputs.updated == 'true'
-      run: |
-        gh pr create \
-          --title "chore(deps): update tooling and dependencies" \
-          --body "$(cat <<'EOF'
-        This PR was created automatically by the scheduled `update` workflow.
-
-        Updated versions:
-        - Go: `${{ steps.update.outputs.go_version }}`
-        - golangci-lint: `${{ steps.update.outputs.golangci_tag }}`
-        - terraform-plugin-docs: `${{ steps.update.outputs.tfplugindocs_tag }}`
-        - actionlint: `${{ steps.update.outputs.actionlint_tag }}`
-        - shellcheck: `${{ steps.update.outputs.shellcheck_tag }}`
-
-        Included actions:
-        - Updated Makefile tooling pins
-        - Updated CI pins in `.github/workflows/lint.yml`
-        - Ran `make update` to refresh Go dependencies
-        - Ran `make` to validate lint/test/build
-        EOF
-        )" \
-          --base main \
-          --head "${{ steps.update.outputs.branch_name }}"
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          Included actions:
+          - Updated Makefile tooling pins
+          - Updated CI pins in `.github/workflows/lint.yml`
+          - Ran `make update` to refresh Go dependencies
+          - Ran `make` to validate lint/test/build
+          EOF
+          )" \
+            --base main \
+            --head "${{ steps.update.outputs.branch_name }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,44 +2,29 @@ name: Update
 
 on:
   schedule:
-  # Run weekly on Mondays at 10:00 UTC
-  - cron: 0 10 * * 1
+    # Run weekly on Mondays at 10:00 UTC
+    - cron: 0 10 * * 1
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: update
+  cancel-in-progress: false
+
 jobs:
-  go:
-    name: Go
+  dependencies-and-tooling:
+    name: Dependencies and Tooling
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Get Latest Go Version
-      id: latest-version
-      run: |
-        # Get the latest stable Go version from the Go API.
-        LATEST_VERSION=$(curl -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version' | sed 's/go//')
-        echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-    - name: Get Current Go Version
-      id: current-version
-      run: |
-        # Get the current version from the Makefile.
-        CURRENT_VERSION=$(grep "^go_version" Makefile | tr -s ' ' | cut -d' ' -f3)
-        echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-    - name: Compare Go Versions
-      id: compare-versions
-      run: |
-        if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
-          echo "update=true" >> "$GITHUB_OUTPUT"
-        fi
     - name: Check for an Existing Pull Request
       id: check-open-pull-requests
-      if: steps.compare-versions.outputs.update == 'true'
       run: |
-        BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
+        BRANCH_NAME="update/dependencies-and-tooling"
         if gh pr list --head "$BRANCH_NAME" --state open --json number | jq -e '. | length > 0' >/dev/null; then
           echo "exists=true" >> "$GITHUB_OUTPUT"
         else
@@ -47,36 +32,121 @@ jobs:
         fi
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-    - name: Create Branch and Update Go Version
-      if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+    - name: Create Branch and Update Dependencies/Tooling
+      id: update
+      if: steps.check-open-pull-requests.outputs.exists == 'false'
       run: |
+        set -euo pipefail
+
+        latest_release_tag() {
+          local repo="$1"
+          curl --silent --show-error --fail \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${repo}/releases/latest" \
+          | jq -r '.tag_name'
+        }
+
+        latest_stable_go_version() {
+          curl --silent --show-error --fail "https://go.dev/dl/?mode=json" \
+          | jq -r '[.[] | select(.stable == true)][0].version | sub("^go"; "")'
+        }
+
+        # Discover latest versions.
+        GO_VERSION="$(latest_stable_go_version)"
+        GOLANGCI_TAG="$(latest_release_tag "golangci/golangci-lint")"
+        TFPLUGINDOCS_TAG="$(latest_release_tag "hashicorp/terraform-plugin-docs")"
+        ACTIONLINT_TAG="$(latest_release_tag "rhysd/actionlint")"
+        SHELLCHECK_TAG="$(latest_release_tag "koalaman/shellcheck")"
+
+        GOLANGCI_VERSION="${GOLANGCI_TAG#v}"
+        TFPLUGINDOCS_VERSION="${TFPLUGINDOCS_TAG#v}"
+        ACTIONLINT_VERSION="${ACTIONLINT_TAG#v}"
+        SHELLCHECK_VERSION="${SHELLCHECK_TAG#v}"
+
+        # Resolve the immutable commit SHA for the actionlint release tag.
+        ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}^{}" | awk '{print $1}')"
+        if [ -z "${ACTIONLINT_SHA}" ]; then
+          ACTIONLINT_SHA="$(git ls-remote https://github.com/rhysd/actionlint "refs/tags/${ACTIONLINT_TAG}" | awk '{print $1}')"
+        fi
+
+        if [ -z "${ACTIONLINT_SHA}" ]; then
+          echo "Failed to resolve SHA for actionlint tag ${ACTIONLINT_TAG}."
+          exit 1
+        fi
+
         git config --global user.name "craigsloggett"
         git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
-        BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
-        git checkout -b "$BRANCH_NAME"
+        BRANCH_NAME="update/dependencies-and-tooling"
+        git checkout -B "$BRANCH_NAME"
 
-        sed -i "s/^go_version.*:= .*/go_version           := ${{ steps.latest-version.outputs.version }}/" Makefile
-        sed -i "s/^go .*/go ${{ steps.latest-version.outputs.version }}/" go.mod
+        # Update local tool versions.
+        sed -i "s/^go_version[[:space:]]*:= .*/go_version           := ${GO_VERSION}/" Makefile
+        sed -i "s/^golangci_version[[:space:]]*:= .*/golangci_version     := ${GOLANGCI_VERSION}/" Makefile
+        sed -i "s/^tfplugindocs_version[[:space:]]*:= .*/tfplugindocs_version := ${TFPLUGINDOCS_VERSION}/" Makefile
+        sed -i "s/^actionlint_version[[:space:]]*:= .*/actionlint_version   := ${ACTIONLINT_VERSION}/" Makefile
+        sed -i "s/^shellcheck_version[[:space:]]*:= .*/shellcheck_version   := ${SHELLCHECK_VERSION}/" Makefile
 
-        git add Makefile go.mod
-        git commit -m "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}"
+        # Keep go.mod and CI aligned with the configured Go/tooling versions.
+        sed -i "s/^go .*/go ${GO_VERSION}/" go.mod
+        sed -i "s/^\([[:space:]]*go-version: \).*/\1${GO_VERSION}/" .github/workflows/lint.yml
+        sed -i "s|^\([[:space:]]*go install github.com/rhysd/actionlint/cmd/actionlint@\).*|\1${ACTIONLINT_SHA} # ${ACTIONLINT_TAG}|" .github/workflows/lint.yml
+        sed -i "s/^\([[:space:]]*version: \).*/\1${GOLANGCI_TAG}/" .github/workflows/lint.yml
 
+        # Refresh provider dependencies and validate.
         make clean
         make update
-        git add go.mod go.sum
-        git commit -m "chore(deps): Update dependencies"
+        make
 
-        git push origin "$BRANCH_NAME"
+        if git diff --quiet; then
+          echo "No updates available."
+          {
+            echo "updated=false"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
 
-        echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+        git add Makefile go.mod go.sum .github/workflows/lint.yml
+        git commit -m "chore(deps): update tooling and dependencies"
+
+        git push --force-with-lease origin "$BRANCH_NAME"
+
+        {
+          echo "updated=true"
+          echo "branch_name=${BRANCH_NAME}"
+          echo "go_version=${GO_VERSION}"
+          echo "golangci_tag=${GOLANGCI_TAG}"
+          echo "tfplugindocs_tag=${TFPLUGINDOCS_TAG}"
+          echo "actionlint_tag=${ACTIONLINT_TAG}"
+          echo "shellcheck_tag=${SHELLCHECK_TAG}"
+        } >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
     - name: Create Pull Request
-      if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+      if: steps.check-open-pull-requests.outputs.exists == 'false' && steps.update.outputs.updated == 'true'
       run: |
         gh pr create \
-          --title "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}" \
-          --body "Automated update of Go from v${{ steps.current-version.outputs.version }} to v${{ steps.latest-version.outputs.version }}." \
+          --title "chore(deps): update tooling and dependencies" \
+          --body "$(cat <<'EOF'
+        This PR was created automatically by the scheduled `update` workflow.
+
+        Updated versions:
+        - Go: `${{ steps.update.outputs.go_version }}`
+        - golangci-lint: `${{ steps.update.outputs.golangci_tag }}`
+        - terraform-plugin-docs: `${{ steps.update.outputs.tfplugindocs_tag }}`
+        - actionlint: `${{ steps.update.outputs.actionlint_tag }}`
+        - shellcheck: `${{ steps.update.outputs.shellcheck_tag }}`
+
+        Included actions:
+        - Updated Makefile tooling pins
+        - Updated CI pins in `.github/workflows/lint.yml`
+        - Ran `make update` to refresh Go dependencies
+        - Ran `make` to validate lint/test/build
+        EOF
+        )" \
           --base main \
-          --head "${{ env.BRANCH_NAME }}"
+          --head "${{ steps.update.outputs.branch_name }}"
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,6 @@
+formatter:
+  type: basic
+  indent: 2
+  indentless_arrays: false
+  retain_line_breaks_single: true
+  trim_trailing_whitespace: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -30,4 +30,5 @@ rules:
     quote-type: single
     required: only-when-needed
 
-  line-length: disable
+  line-length:
+    max: 120

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 BIN           := $(PWD)/.local/bin
 CACHE         := $(PWD)/.local/cache
 GOPATH        := $(CACHE)/go
+VENV          := $(CACHE)/venv
 PATH          := $(BIN):$(PATH)
 SHELL         := env PATH=$(PATH) GOPATH=$(GOPATH) /bin/sh
+PYTHON        ?= python3
 PROVIDER_NAME := terraform-provider-github
 
 # Versions
@@ -11,6 +13,8 @@ golangci_version     := 2.10.1
 tfplugindocs_version := 0.24.0
 actionlint_version   := 1.7.11
 shellcheck_version   := 0.11.0
+yamlfmt_version      := 0.21.0
+yamllint_version     := 1.37.1
 
 # Operating System and Architecture
 os ?= $(shell uname|tr A-Z a-z)
@@ -27,7 +31,7 @@ endif
 all: lint test build
 
 .PHONY: tools
-tools: $(BIN)/go $(BIN)/golangci-lint $(BIN)/tfplugindocs $(BIN)/actionlint $(BIN)/shellcheck
+tools: $(BIN)/go $(BIN)/golangci-lint $(BIN)/tfplugindocs $(BIN)/actionlint $(BIN)/shellcheck $(BIN)/yamlfmt $(BIN)/yamllint
 
 # Setup Go
 go_package_name := go$(go_version).$(os)-$(arch)
@@ -93,6 +97,26 @@ $(BIN)/shellcheck:
 	@tar -C $(BIN) -xf $(BIN)/$(shellcheck_package_name).tar.xz && rm $(BIN)/$(shellcheck_package_name).tar.xz
 	@ln -s $(shellcheck_install_path)/shellcheck $(BIN)/shellcheck
 
+# Setup yamlfmt
+$(BIN)/yamlfmt: $(BIN)/go
+	@mkdir -p $(BIN)
+	@echo "Installing yamlfmt $(yamlfmt_version)..."
+	@go install github.com/google/yamlfmt/cmd/yamlfmt@v$(yamlfmt_version)
+	@ln -s $(GOPATH)/bin/yamlfmt $(BIN)/yamlfmt
+
+# Setup yamllint
+$(VENV)/bin/pip:
+	@mkdir -p $(CACHE)
+	@echo "Creating Python virtual environment at $(VENV)..."
+	@$(PYTHON) -m venv $(VENV)
+
+$(BIN)/yamllint: $(VENV)/bin/pip
+	@mkdir -p $(BIN)
+	@echo "Installing yamllint $(yamllint_version)..."
+	@$(VENV)/bin/pip install --upgrade pip
+	@$(VENV)/bin/pip install yamllint==$(yamllint_version)
+	@ln -s $(VENV)/bin/yamllint $(BIN)/yamllint
+
 .PHONY: update
 update: $(BIN)/go
 	@echo "Updating dependencies..."
@@ -113,12 +137,15 @@ install: build
 format: tools
 	@echo "Formatting..."
 	@go fmt ./...
+	@yamlfmt -conf .yamlfmt .github/workflows/*.yml
 
 .PHONY: lint
 lint: tools
 	@echo "Linting..."
 	@golangci-lint run ./...
 	@actionlint
+	@yamlfmt -conf .yamlfmt -lint .github/workflows/*.yml
+	@yamllint .github/workflows
 	@find . -type f -name '*.sh' \
 		-not -path './.git/*' \
 		-not -path './.local/*' \

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ lint: tools
 	| while IFS= read -r file; do shellcheck "$${file}"; done
 
 .PHONY: docs
-docs: tools install
+docs: $(BIN)/tfplugindocs install
 	@echo "Generating Docs..."
 	@$(BIN)/./tfplugindocs generate -rendered-provider-name "GitHub" >/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint: tools
 	@golangci-lint run ./...
 	@actionlint
 	@yamlfmt -conf .yamlfmt -lint .github/workflows/*.yml
-	@yamllint .github/workflows
+	@yamllint --strict .github/workflows
 	@find . -type f -name '*.sh' \
 		-not -path './.git/*' \
 		-not -path './.local/*' \

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -9,8 +9,6 @@ description: |-
 
 This resource allows you to create and manage repositories within your GitHub organization or personal account.
 
-This is a test.
-
 ## Example Usage
 
 ### Standard

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -9,6 +9,8 @@ description: |-
 
 This resource allows you to create and manage repositories within your GitHub organization or personal account.
 
+This is a test.
+
 ## Example Usage
 
 ### Standard

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -112,6 +112,8 @@ resource "github_repository" "example" {
 ## Import
 
 ```shell
+#!/bin/sh
+
 # Repositories can be imported using the numerical
 # GitHub ID of the repository.
 terraform import github_repository.test 123456789

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,8 @@ gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc h1:51Wupg8spF+5FC6D+iMKbOddFjMckETnNnEiZ+HX37s=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 h1:ggcbiqK8WWh6l1dnltU4BgWGIGo+EVYxCaAPih/zQXQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.79.1 h1:zGhSi45ODB9/p3VAawt9a+O/MULLl9dpizzNNpq7flY=
 google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=


### PR DESCRIPTION
Expand the scheduled update workflow to cover the full maintenance flow. The workflow now updates Makefile tool pins, aligns Go and lint workflow versions, refreshes Go module dependencies, and validates the result before opening a pull request.

The workflow now:
- checks for an existing update PR and exits if one is already open
- discovers latest tool versions from upstream release APIs
- resolves `actionlint` to a commit SHA (like dependabot)
- updates Makefile, go.mod, and lint workflow pins
- runs make clean, make update, and make for validation
- creates a PR only when changes are present

Tradeoffs and limitations:
- this increases workflow complexity and depends on external APIs
- all updates are bundled into one PR instead of separate PRs by type