### PR TITLE
chore(deps): Update Go 1.26.1, go-github v84, and golangci-lint 2.11.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,84 +1,84 @@
 name: Lint
 
 on:
-- pull_request
+  - pull_request
 
 jobs:
   actionlint:
     name: GitHub Actions
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version: 1.26.0
-        cache: false
-    - name: Install actionlint
-      run: |
-        go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
-    - name: Lint Workflow Files
-      run: |
-        actionlint -color
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: 1.26.0
+          cache: false
+      - name: Install actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+      - name: Lint Workflow Files
+        run: |
+          actionlint -color
   yamllint:
     name: YAML
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: 3.14.0
-    - name: Install yamllint
-      run: |
-        pip install --upgrade pip
-        pip install yamllint
-    - name: Lint YAML Files
-      run: |
-        yamllint .
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.14.0
+      - name: Install yamllint
+        run: |
+          pip install --upgrade pip
+          pip install yamllint
+      - name: Lint YAML Files
+        run: |
+          yamllint .
   golangci-lint:
     name: Go
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Lint Go Files
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-      with:
-        version: v2.10.1
-        skip-pkg-cache: true
-        skip-build-cache: true
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Lint Go Files
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.3
+          skip-pkg-cache: true
+          skip-build-cache: true
   terraform-fmt:
     name: Terraform
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-      with:
-        terraform_version: 1.14.0
-    - name: Lint Terraform Files
-      run: |
-        terraform fmt -recursive -check
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: 1.14.0
+      - name: Lint Terraform Files
+        run: |
+          terraform fmt -recursive -check
   tfplugindocs:
     name: Docs
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Validate Docs
-      run: |-
-        echo "Validate the docs have been generated."
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Validate Docs
+        run: |-
+          echo "Validate the docs have been generated."

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL         := env PATH=$(PATH) GOPATH=$(GOPATH) /bin/sh
 PROVIDER_NAME := terraform-provider-github
 
 # Versions
-go_version           := 1.26.0
-golangci_version     := 2.10.1
+go_version           := 1.26.1
+golangci_version     := 2.11.3
 tfplugindocs_version := 0.24.0
 actionlint_version   := 1.7.11
 shellcheck_version   := 0.11.0

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/craigsloggett/terraform-provider-github
 
-go 1.26.0
+go 1.26.1
 
 require (
-	github.com/google/go-github/v79 v79.0.0
+	github.com/google/go-github/v84 v84.0.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v79 v79.0.0 h1:MdodQojuFPBhmtwHiBcIGLw/e/wei2PvFX9ndxK0X4Y=
-github.com/google/go-github/v79 v79.0.0/go.mod h1:OAFbNhq7fQwohojb06iIIQAB9CBGYLq999myfUFnrS4=
+github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD2w+yVA=
+github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/craigsloggett/terraform-provider-github/internal/functions"
 
-	"github.com/google/go-github/v79/github"
+	"github.com/google/go-github/v84/github"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"

--- a/internal/provider/repository_data_source.go
+++ b/internal/provider/repository_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v79/github"
+	"github.com/google/go-github/v84/github"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -915,11 +915,11 @@ func (d *GitHubRepositoryDataSource) Read(ctx context.Context, req datasource.Re
 	model.Organization = &organizationModel{}
 	model.Organization.Name = types.StringValue(organization.GetLogin())
 	model.Permissions = &permissionsModel{}
-	model.Permissions.Admin = types.BoolValue(permissions["admin"])
-	model.Permissions.Pull = types.BoolValue(permissions["pull"])
-	model.Permissions.Triage = types.BoolValue(permissions["triage"])
-	model.Permissions.Push = types.BoolValue(permissions["push"])
-	model.Permissions.Maintain = types.BoolValue(permissions["maintain"])
+	model.Permissions.Admin = types.BoolValue(permissions.GetAdmin())
+	model.Permissions.Pull = types.BoolValue(permissions.GetPull())
+	model.Permissions.Triage = types.BoolValue(permissions.GetTriage())
+	model.Permissions.Push = types.BoolValue(permissions.GetPush())
+	model.Permissions.Maintain = types.BoolValue(permissions.GetMaintain())
 	model.AllowRebaseMerge = types.BoolValue(repo.GetAllowRebaseMerge())
 	model.AllowUpdateBranch = types.BoolValue(repo.GetAllowUpdateBranch())
 	model.AllowSquashMerge = types.BoolValue(repo.GetAllowSquashMerge())

--- a/internal/provider/repository_resource.go
+++ b/internal/provider/repository_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/google/go-github/v79/github"
+	"github.com/google/go-github/v84/github"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -81,37 +81,37 @@ const (
 
 func expandRepository(model GitHubRepositoryResourceModel, mode expansionMode) *github.Repository {
 	repo := &github.Repository{
-		Name:                github.Ptr(model.Name.ValueString()),
-		Description:         github.Ptr(model.Description.ValueString()),
-		Homepage:            github.Ptr(model.Homepage.ValueString()),
-		Private:             github.Ptr(model.Private.ValueBool()),
-		HasIssues:           github.Ptr(model.HasIssues.ValueBool()),
-		HasProjects:         github.Ptr(model.HasProjects.ValueBool()),
-		HasWiki:             github.Ptr(model.HasWiki.ValueBool()),
-		HasDiscussions:      github.Ptr(model.HasDiscussions.ValueBool()),
-		AllowSquashMerge:    github.Ptr(model.AllowSquashMerge.ValueBool()),
-		AllowMergeCommit:    github.Ptr(model.AllowMergeCommit.ValueBool()),
-		AllowRebaseMerge:    github.Ptr(model.AllowRebaseMerge.ValueBool()),
-		AllowAutoMerge:      github.Ptr(model.AllowAutoMerge.ValueBool()),
-		DeleteBranchOnMerge: github.Ptr(model.DeleteBranchOnMerge.ValueBool()),
-		IsTemplate:          github.Ptr(model.IsTemplate.ValueBool()),
+		Name:                new(model.Name.ValueString()),
+		Description:         new(model.Description.ValueString()),
+		Homepage:            new(model.Homepage.ValueString()),
+		Private:             new(model.Private.ValueBool()),
+		HasIssues:           new(model.HasIssues.ValueBool()),
+		HasProjects:         new(model.HasProjects.ValueBool()),
+		HasWiki:             new(model.HasWiki.ValueBool()),
+		HasDiscussions:      new(model.HasDiscussions.ValueBool()),
+		AllowSquashMerge:    new(model.AllowSquashMerge.ValueBool()),
+		AllowMergeCommit:    new(model.AllowMergeCommit.ValueBool()),
+		AllowRebaseMerge:    new(model.AllowRebaseMerge.ValueBool()),
+		AllowAutoMerge:      new(model.AllowAutoMerge.ValueBool()),
+		DeleteBranchOnMerge: new(model.DeleteBranchOnMerge.ValueBool()),
+		IsTemplate:          new(model.IsTemplate.ValueBool()),
 	}
 
 	// Create is the only time you can successfully pass these parameters into the GitHub API.
 	if mode == expandForCreate {
-		repo.AutoInit = github.Ptr(model.AutoInit.ValueBool())
-		repo.GitignoreTemplate = github.Ptr(model.GitignoreTemplate.ValueString())
-		repo.LicenseTemplate = github.Ptr(model.LicenseTemplate.ValueString())
+		repo.AutoInit = new(model.AutoInit.ValueBool())
+		repo.GitignoreTemplate = new(model.GitignoreTemplate.ValueString())
+		repo.LicenseTemplate = new(model.LicenseTemplate.ValueString())
 	}
 
 	if model.AllowSquashMerge.ValueBool() {
-		repo.SquashMergeCommitTitle = github.Ptr(model.SquashMergeCommitTitle.ValueString())
-		repo.SquashMergeCommitMessage = github.Ptr(model.SquashMergeCommitMessage.ValueString())
+		repo.SquashMergeCommitTitle = new(model.SquashMergeCommitTitle.ValueString())
+		repo.SquashMergeCommitMessage = new(model.SquashMergeCommitMessage.ValueString())
 	}
 
 	if model.AllowMergeCommit.ValueBool() {
-		repo.MergeCommitTitle = github.Ptr(model.MergeCommitTitle.ValueString())
-		repo.MergeCommitMessage = github.Ptr(model.MergeCommitMessage.ValueString())
+		repo.MergeCommitTitle = new(model.MergeCommitTitle.ValueString())
+		repo.MergeCommitMessage = new(model.MergeCommitMessage.ValueString())
 	}
 
 	return repo
@@ -528,10 +528,10 @@ func (r *GitHubRepositoryResource) Create(ctx context.Context, req resource.Crea
 		}
 
 		templateReq := &github.TemplateRepoRequest{
-			Name:        github.Ptr(model.Name.ValueString()),
-			Owner:       github.Ptr(owner), // The owner (org) where the new repository will be created.
-			Description: github.Ptr(model.Description.ValueString()),
-			Private:     github.Ptr(model.Private.ValueBool()),
+			Name:        new(model.Name.ValueString()),
+			Owner:       new(owner), // The owner (org) where the new repository will be created.
+			Description: new(model.Description.ValueString()),
+			Private:     new(model.Private.ValueBool()),
 		}
 
 		_, _, err = client.Repositories.CreateFromTemplate(ctx, templateOwner, templateRepo, templateReq)


### PR DESCRIPTION
- Bump Go from 1.26.0 to 1.26.1 in Makefile to match go.mod.
- Bump google/go-github from v79 to v84, adapting to breaking changes: Repository.Permissions is now a struct (v82), requiring getter methods and github.Ptr() removed in favor of builtin new().
- Bump golangci-lint from 2.10.1 to 2.11.3 in Makefile and CI workflow.