### PR TITLE
chore: Align project tooling and CI with template conventions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -63,7 +62,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Check go.mod and go.sum
         run: |
@@ -82,7 +80,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -119,7 +116,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Validate Docs
         run: |-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,4 +119,6 @@ jobs:
 
       - name: Validate Docs
         run: |-
-          echo "Validate the docs have been generated."
+          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 generate \
+            -rendered-provider-name "GitHub" >/dev/null
+          git diff --exit-code docs/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,6 +119,7 @@ jobs:
 
       - name: Validate Docs
         run: |-
+          go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 validate
           go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 generate \
             -rendered-provider-name "GitHub" >/dev/null
           git diff --exit-code docs/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,7 +85,7 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,84 +1,126 @@
 name: Lint
 
-on:
-  - pull_request
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   actionlint:
     name: GitHub Actions
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-        with:
-          go-version: 1.26.0
-          cache: false
-      - name: Install actionlint
-        run: |
-          go install github.com/rhysd/actionlint/cmd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+
       - name: Lint Workflow Files
-        run: |
-          actionlint -color
+        uses: craigsloggett/lint-github-actions-workflows@bf90c927b04eeaffc4cc111083e351de7582b91e # v1.0.2
+
   yamllint:
     name: YAML
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.14.0
-      - name: Install yamllint
-        run: |
-          pip install --upgrade pip
-          pip install yamllint
+
       - name: Lint YAML Files
-        run: |
-          yamllint .
+        uses: craigsloggett/lint-yaml@767c98fbb0be59f22ddd48a920ec80b0666c61db # v1.0.9
+
   golangci-lint:
     name: Go
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
           cache: true
+
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3
-          skip-pkg-cache: true
-          skip-build-cache: true
-  terraform-fmt:
-    name: Terraform
+
+  tidy:
+    name: Go Mod Tidy
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
-        with:
-          terraform_version: 1.14.0
-      - name: Lint Terraform Files
-        run: |
-          terraform fmt -recursive -check
-  tfplugindocs:
-    name: Docs
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Check go.mod and go.sum
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+  govulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  terraform-fmt:
+    name: Terraform
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: 1.14.0
+
+      - name: Lint Terraform Files
+        run: |
+          terraform fmt -recursive -check
+
+  tfplugindocs:
+    name: Docs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Validate Docs
         run: |-
           echo "Validate the docs have been generated."

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,9 +3,9 @@ name: Pre-release
 on:
   pull_request_target:
     types:
-    - opened
-    - edited
-    - synchronize
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: read
@@ -15,8 +15,8 @@ jobs:
     name: Semantic Title
     runs-on: ubuntu-22.04
     steps:
-    - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
-      with:
-        requireScope: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
+        with:
+          requireScope: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 
 on:
   workflow_run:
-    workflows:
-      - Test
     branches:
       - main
+    workflows:
+      - Test
     types:
       - completed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Test
     branches:
-    - main
+      - main
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -12,48 +20,54 @@ permissions:
 
 jobs:
   release:
-    name: Tag Release
+    name: GitHub
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Release
-      uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
-      id: release
-      with:
-        semantic_version: 25.0.2
-        extra_plugins: |
-          @semantic-release/git@10.0.1
-          conventional-changelog-conventionalcommits@9.1.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+    timeout-minutes: 15
+
     outputs:
-      new_release_published: ${{ steps.release.outputs.new_release_published }}
+      new-release-published: ${{ steps.release.outputs.new-release-published }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create a GitHub Release
+        id: release
+        uses: craigsloggett/create-github-release@bef3a8d44ef83bb53291139c5757dab76d087f16 # v1.0.9
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+
   goreleaser:
     name: GoReleaser
     needs: release
-    if: needs.release.outputs.new_release_published == 'true'
+    if: needs.release.outputs.new-release-published == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
-    - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version-file: go.mod
-        cache: true
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-      id: import_gpg
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
-      with:
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Run Tests
         run: go test -race -count=1 ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Go
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Tests
+        run: go test -race -count=1 ./...

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: true
 
       - name: Get Latest Version
         id: latest-version

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,3 +1,4 @@
+# TODO: Extract individual tool updates into composite actions to reduce complexity.
 name: Update
 
 on:
@@ -15,32 +16,72 @@ permissions:
   pull-requests: write
 
 jobs:
-  golangci-lint:
-    name: golangci-lint
+  update:
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - golangci-lint
+          - govulncheck
+          - terraform
+    name: ${{ matrix.tool }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Get Latest Version
         id: latest-version
         run: |
-          VERSION=$(gh api repos/golangci/golangci-lint/releases/latest --jq '.tag_name')
+          case "${{ matrix.tool }}" in
+            golangci-lint)
+              VERSION=$(go list -m -json github.com/golangci/golangci-lint/v2@latest | jq -r '.Version')
+              ;;
+            govulncheck)
+              VERSION=$(go list -m -json golang.org/x/vuln@latest | jq -r '.Version')
+              ;;
+            terraform)
+              VERSION=$(gh api repos/hashicorp/terraform/releases/latest --jq '.tag_name' | sed 's/^v//')
+              ;;
+          esac
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get Current Version
-        id: current-version
+      - name: Get Current Versions
+        id: current-versions
         run: |
-          VERSION=$(sed -n 's/^GOLANGCI_LINT_VERSION := //p' Makefile)
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          case "${{ matrix.tool }}" in
+            golangci-lint)
+              WORKFLOW=$(sed -n 's/.*version: //p' .github/workflows/lint.yml)
+              MAKEFILE=$(sed -n 's/^GOLANGCI_LINT_VERSION := //p' Makefile)
+              ;;
+            govulncheck)
+              WORKFLOW=$(sed -n 's/.*govulncheck@//p' .github/workflows/lint.yml)
+              MAKEFILE=$(sed -n 's/^GOVULNCHECK_VERSION[[:space:]]*:= //p' Makefile)
+              ;;
+            terraform)
+              WORKFLOW=$(sed -n 's/.*terraform_version: //p' .github/workflows/lint.yml)
+              MAKEFILE="${WORKFLOW}"
+              ;;
+          esac
+          echo "workflow=${WORKFLOW}" >> "$GITHUB_OUTPUT"
+          echo "makefile=${MAKEFILE}" >> "$GITHUB_OUTPUT"
 
       - name: Compare Versions
         id: compare-versions
         run: |
-          if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
+          LATEST="${{ steps.latest-version.outputs.version }}"
+          WORKFLOW="${{ steps.current-versions.outputs.workflow }}"
+          MAKEFILE="${{ steps.current-versions.outputs.makefile }}"
+          if [ "${LATEST}" != "${WORKFLOW}" ] || [ "${LATEST}" != "${MAKEFILE}" ]; then
             echo "update=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -48,7 +89,7 @@ jobs:
         id: check-open-pull-requests
         if: steps.compare-versions.outputs.update == 'true'
         run: |
-          BRANCH_NAME="update-golangci-lint-${{ steps.latest-version.outputs.version }}"
+          BRANCH_NAME="update-${{ matrix.tool }}-${{ steps.latest-version.outputs.version }}"
           if gh pr list --head "${BRANCH_NAME}" --state open --json number \
             | jq -e '. | length > 0' >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -65,14 +106,27 @@ jobs:
           git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
           LATEST="${{ steps.latest-version.outputs.version }}"
-          BRANCH_NAME="update-golangci-lint-${LATEST}"
+          BRANCH_NAME="update-${{ matrix.tool }}-${LATEST}"
           git checkout -b "${BRANCH_NAME}"
 
-          sed -i "s/^GOLANGCI_LINT_VERSION := .*/GOLANGCI_LINT_VERSION := ${LATEST}/" Makefile
-          sed -i "s/version: v.*/version: ${LATEST}/" .github/workflows/lint.yml
+          case "${{ matrix.tool }}" in
+            golangci-lint)
+              sed -i "s/^GOLANGCI_LINT_VERSION := .*/GOLANGCI_LINT_VERSION := ${LATEST}/" Makefile
+              sed -i "s/version: v.*/version: ${LATEST}/" .github/workflows/lint.yml
+              git add Makefile .github/workflows/lint.yml
+              ;;
+            govulncheck)
+              sed -i "s/^GOVULNCHECK_VERSION[[:space:]]*:= .*/GOVULNCHECK_VERSION   := ${LATEST}/" Makefile
+              sed -i "s/govulncheck@.*/govulncheck@${LATEST}/" .github/workflows/lint.yml
+              git add Makefile .github/workflows/lint.yml
+              ;;
+            terraform)
+              sed -i "s/terraform_version: .*/terraform_version: ${LATEST}/" .github/workflows/lint.yml
+              git add .github/workflows/lint.yml
+              ;;
+          esac
 
-          git add Makefile .github/workflows/lint.yml
-          git commit -m "chore(deps): Update golangci-lint to ${LATEST}"
+          git commit -m "chore(deps): Update ${{ matrix.tool }} to ${LATEST}"
 
           git push origin "${BRANCH_NAME}"
 
@@ -82,87 +136,12 @@ jobs:
         if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
         run: |
           LATEST="${{ steps.latest-version.outputs.version }}"
-          CURRENT="${{ steps.current-version.outputs.version }}"
+          WORKFLOW="${{ steps.current-versions.outputs.workflow }}"
+          MAKEFILE="${{ steps.current-versions.outputs.makefile }}"
 
           gh pr create \
-            --title "chore(deps): Update golangci-lint to ${LATEST}" \
-            --body "Update golangci-lint from ${CURRENT} to ${LATEST}." \
-            --base main \
-            --head "${{ env.BRANCH_NAME }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  terraform:
-    name: Terraform
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Get Latest Version
-        id: latest-version
-        run: |
-          VERSION=$(gh api repos/hashicorp/terraform/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Current Version
-        id: current-version
-        run: |
-          VERSION=$(sed -n 's/.*terraform_version: //p' .github/workflows/lint.yml)
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Compare Versions
-        id: compare-versions
-        run: |
-          if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
-            echo "update=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check for an Existing Pull Request
-        id: check-open-pull-requests
-        if: steps.compare-versions.outputs.update == 'true'
-        run: |
-          BRANCH_NAME="update-terraform-${{ steps.latest-version.outputs.version }}"
-          if gh pr list --head "${BRANCH_NAME}" --state open --json number \
-            | jq -e '. | length > 0' >/dev/null; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      - name: Create Branch and Update Version
-        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
-        run: |
-          git config --global user.name "craigsloggett"
-          git config --global user.email "684196+craigsloggett@users.noreply.github.com"
-
-          LATEST="${{ steps.latest-version.outputs.version }}"
-          BRANCH_NAME="update-terraform-${LATEST}"
-          git checkout -b "${BRANCH_NAME}"
-
-          sed -i "s/terraform_version: .*/terraform_version: ${LATEST}/" .github/workflows/lint.yml
-
-          git add .github/workflows/lint.yml
-          git commit -m "chore(deps): Update Terraform to v${LATEST}"
-
-          git push origin "${BRANCH_NAME}"
-
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
-
-      - name: Create Pull Request
-        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
-        run: |
-          LATEST="${{ steps.latest-version.outputs.version }}"
-          CURRENT="${{ steps.current-version.outputs.version }}"
-
-          gh pr create \
-            --title "chore(deps): Update Terraform to v${LATEST}" \
-            --body "Update Terraform from v${CURRENT} to v${LATEST}." \
+            --title "chore(deps): Update ${{ matrix.tool }} to ${LATEST}" \
+            --body "Update ${{ matrix.tool }} to ${LATEST} (workflow: ${WORKFLOW}, Makefile: ${MAKEFILE})." \
             --base main \
             --head "${{ env.BRANCH_NAME }}"
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,28 +15,29 @@ permissions:
   pull-requests: write
 
 jobs:
-  go:
-    name: Go
+  golangci-lint:
+    name: golangci-lint
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get Latest Go Version
+      - name: Get Latest Version
         id: latest-version
         run: |
-          LATEST_VERSION=$(curl -s "https://go.dev/dl/?mode=json" \
-            | jq -r '.[0].version' | sed 's/go//')
-          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          VERSION=$(gh api repos/golangci/golangci-lint/releases/latest --jq '.tag_name')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get Current Go Version
+      - name: Get Current Version
         id: current-version
         run: |
-          CURRENT_VERSION=$(sed -n 's/^go //p' go.mod)
-          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          VERSION=$(sed -n 's/^GOLANGCI_LINT_VERSION := //p' Makefile)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Compare Go Versions
+      - name: Compare Versions
         id: compare-versions
         run: |
           if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
@@ -47,8 +48,8 @@ jobs:
         id: check-open-pull-requests
         if: steps.compare-versions.outputs.update == 'true'
         run: |
-          BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
-          if gh pr list --head "$BRANCH_NAME" --state open --json number \
+          BRANCH_NAME="update-golangci-lint-${{ steps.latest-version.outputs.version }}"
+          if gh pr list --head "${BRANCH_NAME}" --state open --json number \
             | jq -e '. | length > 0' >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -57,27 +58,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Create Branch and Update Go Version
+      - name: Create Branch and Update Version
         if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
         run: |
           git config --global user.name "craigsloggett"
           git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
-          BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
-          git checkout -b "$BRANCH_NAME"
+          LATEST="${{ steps.latest-version.outputs.version }}"
+          BRANCH_NAME="update-golangci-lint-${LATEST}"
+          git checkout -b "${BRANCH_NAME}"
 
-          sed -i "s/^go .*/go ${{ steps.latest-version.outputs.version }}/" go.mod
+          sed -i "s/^GOLANGCI_LINT_VERSION := .*/GOLANGCI_LINT_VERSION := ${LATEST}/" Makefile
+          sed -i "s/version: v.*/version: ${LATEST}/" .github/workflows/lint.yml
 
-          git add go.mod
-          git commit -m "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}"
+          git add Makefile .github/workflows/lint.yml
+          git commit -m "chore(deps): Update golangci-lint to ${LATEST}"
 
-          make update
-          git add go.mod go.sum
-          git commit -m "chore(deps): Update dependencies"
+          git push origin "${BRANCH_NAME}"
 
-          git push origin "$BRANCH_NAME"
-
-          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
 
       - name: Create Pull Request
         if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
@@ -86,8 +85,84 @@ jobs:
           CURRENT="${{ steps.current-version.outputs.version }}"
 
           gh pr create \
-            --title "chore(deps): Update Go to v${LATEST}" \
-            --body "Update Go from v${CURRENT} to v${LATEST}." \
+            --title "chore(deps): Update golangci-lint to ${LATEST}" \
+            --body "Update golangci-lint from ${CURRENT} to ${LATEST}." \
+            --base main \
+            --head "${{ env.BRANCH_NAME }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get Latest Version
+        id: latest-version
+        run: |
+          VERSION=$(gh api repos/hashicorp/terraform/releases/latest --jq '.tag_name' | sed 's/^v//')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Current Version
+        id: current-version
+        run: |
+          VERSION=$(sed -n 's/.*terraform_version: //p' .github/workflows/lint.yml)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare Versions
+        id: compare-versions
+        run: |
+          if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
+            echo "update=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an Existing Pull Request
+        id: check-open-pull-requests
+        if: steps.compare-versions.outputs.update == 'true'
+        run: |
+          BRANCH_NAME="update-terraform-${{ steps.latest-version.outputs.version }}"
+          if gh pr list --head "${BRANCH_NAME}" --state open --json number \
+            | jq -e '. | length > 0' >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Create Branch and Update Version
+        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+        run: |
+          git config --global user.name "craigsloggett"
+          git config --global user.email "684196+craigsloggett@users.noreply.github.com"
+
+          LATEST="${{ steps.latest-version.outputs.version }}"
+          BRANCH_NAME="update-terraform-${LATEST}"
+          git checkout -b "${BRANCH_NAME}"
+
+          sed -i "s/terraform_version: .*/terraform_version: ${LATEST}/" .github/workflows/lint.yml
+
+          git add .github/workflows/lint.yml
+          git commit -m "chore(deps): Update Terraform to v${LATEST}"
+
+          git push origin "${BRANCH_NAME}"
+
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+
+      - name: Create Pull Request
+        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+        run: |
+          LATEST="${{ steps.latest-version.outputs.version }}"
+          CURRENT="${{ steps.current-version.outputs.version }}"
+
+          gh pr create \
+            --title "chore(deps): Update Terraform to v${LATEST}" \
+            --body "Update Terraform from v${CURRENT} to v${LATEST}." \
             --base main \
             --head "${{ env.BRANCH_NAME }}"
         env:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,6 +23,7 @@ jobs:
         tool:
           - golangci-lint
           - govulncheck
+          - tfplugindocs
           - terraform
     name: ${{ matrix.tool }}
     runs-on: ubuntu-24.04
@@ -46,6 +47,9 @@ jobs:
             govulncheck)
               VERSION=$(go list -m -json golang.org/x/vuln@latest | jq -r '.Version')
               ;;
+            tfplugindocs)
+              VERSION=$(go list -m -json github.com/hashicorp/terraform-plugin-docs@latest | jq -r '.Version')
+              ;;
             terraform)
               VERSION=$(gh api repos/hashicorp/terraform/releases/latest --jq '.tag_name' | sed 's/^v//')
               ;;
@@ -65,6 +69,10 @@ jobs:
             govulncheck)
               WORKFLOW=$(sed -n 's/.*govulncheck@//p' .github/workflows/lint.yml)
               MAKEFILE=$(sed -n 's/^GOVULNCHECK_VERSION[[:space:]]*:= //p' Makefile)
+              ;;
+            tfplugindocs)
+              WORKFLOW=$(sed -n 's/.*tfplugindocs@\([^ ]*\).*/\1/p' .github/workflows/lint.yml)
+              MAKEFILE=$(sed -n 's/^TFPLUGINDOCS_VERSION[[:space:]]*:= //p' Makefile)
               ;;
             terraform)
               WORKFLOW=$(sed -n 's/.*terraform_version: //p' .github/workflows/lint.yml)
@@ -117,6 +125,11 @@ jobs:
             govulncheck)
               sed -i "s/^GOVULNCHECK_VERSION[[:space:]]*:= .*/GOVULNCHECK_VERSION   := ${LATEST}/" Makefile
               sed -i "s/govulncheck@.*/govulncheck@${LATEST}/" .github/workflows/lint.yml
+              git add Makefile .github/workflows/lint.yml
+              ;;
+            tfplugindocs)
+              sed -i "s/^TFPLUGINDOCS_VERSION[[:space:]]*:= .*/TFPLUGINDOCS_VERSION  := ${LATEST}/" Makefile
+              sed -i "s/tfplugindocs@[^ ]*/tfplugindocs@${LATEST}/" .github/workflows/lint.yml
               git add Makefile .github/workflows/lint.yml
               ;;
             terraform)

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,9 +2,13 @@ name: Update
 
 on:
   schedule:
-  # Run weekly on Mondays at 10:00 UTC
-  - cron: 0 10 * * 1
+    # Run weekly on Mondays at 10:00 UTC
+    - cron: 0 10 * * 1
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -14,69 +18,77 @@ jobs:
   go:
     name: Go
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Get Latest Go Version
-      id: latest-version
-      run: |
-        # Get the latest stable Go version from the Go API.
-        LATEST_VERSION=$(curl -s "https://go.dev/dl/?mode=json" | jq -r '.[0].version' | sed 's/go//')
-        echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-    - name: Get Current Go Version
-      id: current-version
-      run: |
-        # Get the current version from the Makefile.
-        CURRENT_VERSION=$(grep "^go_version" Makefile | tr -s ' ' | cut -d' ' -f3)
-        echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-    - name: Compare Go Versions
-      id: compare-versions
-      run: |
-        if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
-          echo "update=true" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Check for an Existing Pull Request
-      id: check-open-pull-requests
-      if: steps.compare-versions.outputs.update == 'true'
-      run: |
-        BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
-        if gh pr list --head "$BRANCH_NAME" --state open --json number | jq -e '. | length > 0' >/dev/null; then
-          echo "exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-        fi
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-    - name: Create Branch and Update Go Version
-      if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
-      run: |
-        git config --global user.name "craigsloggett"
-        git config --global user.email "684196+craigsloggett@users.noreply.github.com"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-        BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
-        git checkout -b "$BRANCH_NAME"
+      - name: Get Latest Go Version
+        id: latest-version
+        run: |
+          LATEST_VERSION=$(curl -s "https://go.dev/dl/?mode=json" \
+            | jq -r '.[0].version' | sed 's/go//')
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
 
-        sed -i "s/^go_version.*:= .*/go_version           := ${{ steps.latest-version.outputs.version }}/" Makefile
-        sed -i "s/^go .*/go ${{ steps.latest-version.outputs.version }}/" go.mod
+      - name: Get Current Go Version
+        id: current-version
+        run: |
+          CURRENT_VERSION=$(sed -n 's/^go //p' go.mod)
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
-        git add Makefile go.mod
-        git commit -m "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}"
+      - name: Compare Go Versions
+        id: compare-versions
+        run: |
+          if [ "${{ steps.latest-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
+            echo "update=true" >> "$GITHUB_OUTPUT"
+          fi
 
-        make clean
-        make update
-        git add go.mod go.sum
-        git commit -m "chore(deps): Update dependencies"
+      - name: Check for an Existing Pull Request
+        id: check-open-pull-requests
+        if: steps.compare-versions.outputs.update == 'true'
+        run: |
+          BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
+          if gh pr list --head "$BRANCH_NAME" --state open --json number \
+            | jq -e '. | length > 0' >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-        git push origin "$BRANCH_NAME"
+      - name: Create Branch and Update Go Version
+        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+        run: |
+          git config --global user.name "craigsloggett"
+          git config --global user.email "684196+craigsloggett@users.noreply.github.com"
 
-        echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
-    - name: Create Pull Request
-      if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
-      run: |
-        gh pr create \
-          --title "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}" \
-          --body "Automated update of Go from v${{ steps.current-version.outputs.version }} to v${{ steps.latest-version.outputs.version }}." \
-          --base main \
-          --head "${{ env.BRANCH_NAME }}"
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          BRANCH_NAME="update-go-${{ steps.latest-version.outputs.version }}"
+          git checkout -b "$BRANCH_NAME"
+
+          sed -i "s/^go .*/go ${{ steps.latest-version.outputs.version }}/" go.mod
+
+          git add go.mod
+          git commit -m "chore(deps): Update Go to v${{ steps.latest-version.outputs.version }}"
+
+          make update
+          git add go.mod go.sum
+          git commit -m "chore(deps): Update dependencies"
+
+          git push origin "$BRANCH_NAME"
+
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
+
+      - name: Create Pull Request
+        if: steps.compare-versions.outputs.update == 'true' && steps.check-open-pull-requests.outputs.exists == 'false'
+        run: |
+          LATEST="${{ steps.latest-version.outputs.version }}"
+          CURRENT="${{ steps.current-version.outputs.version }}"
+
+          gh pr create \
+            --title "chore(deps): Update Go to v${LATEST}" \
+            --body "Update Go from v${CURRENT} to v${LATEST}." \
+            --base main \
+            --head "${{ env.BRANCH_NAME }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,14 +11,22 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Code coverage profiles and other test artifacts
 *.out
+coverage.*
+*.coverprofile
+profile.cov
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
 # Go workspace file
 go.work
+go.work.sum
+
+# env file
+.env
+.env.integration
 
 # Local .terraform directories
 **/.terraform/*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,11 +7,13 @@ issues:
 linters:
   default: none
   enable:
-    - copyloopvar
+    - bodyclose
     - durationcheck
     - errcheck
+    - errorlint
     - forcetypeassert
     - godot
+    - gosec
     - govet
     - ineffassign
     - makezero
@@ -37,6 +39,7 @@ linters:
 formatters:
   enable:
     - gofmt
+    - goimports
   exclusions:
     generated: lax
     paths:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -25,9 +25,11 @@ rules:
   indentation:
     level: error
     spaces: 2
+    indent-sequences: true
 
   quoted-strings:
     quote-type: single
     required: only-when-needed
 
-  line-length: disable
+  line-length:
+    max: 120

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 	go mod tidy
 	git diff --exit-code go.mod go.sum
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
-	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) validate
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) validate 2>/dev/null
 
 docs: install
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) generate \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-PROVIDER_NAME := terraform-provider-github
-BUILD_DIR     := .local/builds
-PLATFORMS     := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+PROVIDER_NAME         := terraform-provider-github
+BUILD_DIR             := .local/builds
+PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+GOLANGCI_LINT_VERSION := v2.11.3
 
 .PHONY: all build clean docs format install lint test testacc update
 
@@ -16,14 +17,15 @@ build:
 			go build -o $(BUILD_DIR)/$(PROVIDER_NAME)-$${os}-$${arch} .; \
 	done
 
-install: build
-	go install .
+install:
+	go install ./...
 
 format:
 	go fmt ./...
 
 lint:
-	golangci-lint run ./...
+	yamllint .
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...
 	actionlint
 	find . -type f -name '*.sh' \
 		-not -path './.git/*' \
@@ -31,10 +33,11 @@ lint:
 	| while IFS= read -r file; do shellcheck "$${file}"; done
 	go mod tidy
 	git diff --exit-code go.mod go.sum
-	govulncheck ./...
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
 docs: install
-	tfplugindocs generate -rendered-provider-name "GitHub" >/dev/null
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate \
+		-rendered-provider-name "GitHub" >/dev/null
 
 test:
 	go test -race -count=1 ./...
@@ -47,4 +50,4 @@ update:
 	go mod tidy
 
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -rf .local/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 GOLANGCI_LINT_VERSION := v2.11.3
 GOVULNCHECK_VERSION   := v1.1.4
+TFPLUGINDOCS_VERSION  := v0.24.0
 
 .PHONY: all build clean docs format install lint test testacc update
 
@@ -37,7 +38,7 @@ lint:
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 docs: install
-	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate \
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) generate \
 		-rendered-provider-name "GitHub" >/dev/null
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PROVIDER_NAME         := terraform-provider-github
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 GOLANGCI_LINT_VERSION := v2.11.3
+GOVULNCHECK_VERSION   := v1.1.4
 
 .PHONY: all build clean docs format install lint test testacc update
 
@@ -33,7 +34,7 @@ lint:
 	| while IFS= read -r file; do shellcheck "$${file}"; done
 	go mod tidy
 	git diff --exit-code go.mod go.sum
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 docs: install
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate \

--- a/Makefile
+++ b/Makefile
@@ -1,150 +1,50 @@
-BIN           := $(PWD)/.local/bin
-CACHE         := $(PWD)/.local/cache
-GOPATH        := $(CACHE)/go
-PATH          := $(BIN):$(PATH)
-SHELL         := env PATH=$(PATH) GOPATH=$(GOPATH) /bin/sh
 PROVIDER_NAME := terraform-provider-github
+BUILD_DIR     := .local/builds
+PLATFORMS     := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
-# Versions
-go_version           := 1.26.1
-golangci_version     := 2.11.3
-tfplugindocs_version := 0.24.0
-actionlint_version   := 1.7.11
-shellcheck_version   := 0.11.0
+.PHONY: all build clean docs format install lint test testacc update
 
-# Operating System and Architecture
-os ?= $(shell uname|tr A-Z a-z)
-
-ifeq ($(shell uname -m),x86_64)
-  arch   ?= amd64
-endif
-ifeq ($(shell uname -m),arm64)
-  arch     ?= arm64
-  arch_alt ?= aarch64
-endif
-
-.PHONY: all
 all: lint test build
 
-.PHONY: tools
-tools: $(BIN)/go $(BIN)/golangci-lint $(BIN)/tfplugindocs $(BIN)/actionlint $(BIN)/shellcheck
+build:
+	@mkdir -p $(BUILD_DIR)
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%/*}; \
+		arch=$${platform#*/}; \
+		echo "Building $(PROVIDER_NAME)-$${os}-$${arch}"; \
+		CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} \
+			go build -o $(BUILD_DIR)/$(PROVIDER_NAME)-$${os}-$${arch} .; \
+	done
 
-# Setup Go
-go_package_name := go$(go_version).$(os)-$(arch)
-go_package_url  := https://go.dev/dl/$(go_package_name).tar.gz
-go_install_path := $(BIN)/go-$(go_version)-$(os)-$(arch)
-
-$(BIN)/go:
-	@mkdir -p $(BIN)
-	@mkdir -p $(GOPATH)
-	@echo "Downloading Go $(go_version) to $(go_install_path)..."
-	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(go_package_url)
-	@tar -C $(BIN) -xzf $(BIN)/$(go_package_name).tar.gz && rm $(BIN)/$(go_package_name).tar.gz
-	@mv $(BIN)/go $(go_install_path)
-	@ln -s $(go_install_path)/bin/go $(BIN)/go
-
-# Setup golangci
-golangci_package_name := golangci-lint-$(golangci_version)-$(os)-$(arch)
-golangci_package_url  := https://github.com/golangci/golangci-lint/releases/download/v$(golangci_version)/$(golangci_package_name).tar.gz
-golangci_install_path := $(BIN)/$(golangci_package_name)
-
-$(BIN)/golangci-lint:
-	@mkdir -p $(BIN)
-	@echo "Downloading golangci-lint $(golangci_version) to $(BIN)/golangci-lint-$(golangci_version)..." #TODO: Update this line to use golangci_install_path
-	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(golangci_package_url)
-	@tar -C $(BIN) -xzf $(BIN)/$(golangci_package_name).tar.gz && rm $(BIN)/$(golangci_package_name).tar.gz
-	@ln -s $(golangci_install_path)/golangci-lint $(BIN)/golangci-lint
-
-# Setup tfplugindocs
-tfplugindocs_package_name := tfplugindocs_$(tfplugindocs_version)_$(os)_$(arch)
-tfplugindocs_package_url  := https://github.com/hashicorp/terraform-plugin-docs/releases/download/v$(tfplugindocs_version)/$(tfplugindocs_package_name).zip
-tfplugindocs_install_path := $(BIN)/$(tfplugindocs_package_name)
-
-$(BIN)/tfplugindocs:
-	@mkdir -p $(BIN)
-	@echo "Downloading tfplugindocs $(tfplugindocs_version) to $(tfplugindocs_install_path)..."
-	@mkdir -p $(tfplugindocs_install_path) # actionlint isn't packaged in a directory
-	@curl --silent --show-error --fail --create-dirs --output-dir $(tfplugindocs_install_path) -O -L $(tfplugindocs_package_url)
-	@cd $(tfplugindocs_install_path) && unzip $(tfplugindocs_package_name).zip && rm $(tfplugindocs_package_name).zip && cd -
-	@ln -s $(tfplugindocs_install_path)/tfplugindocs $(BIN)/tfplugindocs
-
-# Setup actionlint
-actionlint_package_name := actionlint_$(actionlint_version)_$(os)_$(arch)
-actionlint_package_url  := https://github.com/rhysd/actionlint/releases/download/v$(actionlint_version)/$(actionlint_package_name).tar.gz
-actionlint_install_path := $(BIN)/$(actionlint_package_name)
-
-$(BIN)/actionlint:
-	@mkdir -p $(BIN)
-	@echo "Downloading actionlint $(actionlint_version) to $(BIN)/actionlint-$(actionlint_version)..."
-	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(actionlint_package_url)
-	@mkdir -p $(actionlint_install_path) # actionlint isn't packaged in a directory
-	@tar -C $(actionlint_install_path) -xzf $(BIN)/$(actionlint_package_name).tar.gz && rm $(BIN)/$(actionlint_package_name).tar.gz
-	@ln -s $(actionlint_install_path)/actionlint $(BIN)/actionlint
-
-# Setup shellcheck
-shellcheck_package_name := shellcheck-v$(shellcheck_version).$(os).$(arch_alt)
-shellcheck_package_url  := https://github.com/koalaman/shellcheck/releases/download/v$(shellcheck_version)/$(shellcheck_package_name).tar.xz
-shellcheck_install_path := $(BIN)/shellcheck-v$(shellcheck_version)
-
-$(BIN)/shellcheck:
-	@mkdir -p $(BIN)
-	@echo "Downloading shellcheck $(shellcheck_version) to $(BIN)/shellcheck-$(shellcheck_version)..."
-	@curl --silent --show-error --fail --create-dirs --output-dir $(BIN) -O -L $(shellcheck_package_url)
-	@tar -C $(BIN) -xf $(BIN)/$(shellcheck_package_name).tar.xz && rm $(BIN)/$(shellcheck_package_name).tar.xz
-	@ln -s $(shellcheck_install_path)/shellcheck $(BIN)/shellcheck
-
-.PHONY: update
-update: $(BIN)/go
-	@echo "Updating dependencies..."
-	@go get -u
-	@go mod tidy
-
-.PHONY: build
-build: $(BIN)/go
-	@echo "Building..."
-	@go build ./...
-
-.PHONY: install
 install: build
-	@echo "Installing provider..."
-	@go install ./...
+	go install .
 
-.PHONY: format
-format: tools
-	@echo "Formatting..."
-	@go fmt ./...
+format:
+	go fmt ./...
 
-.PHONY: lint
-lint: tools
-	@echo "Linting..."
-	@golangci-lint run ./...
-	@actionlint
-	@find . -type f -name '*.sh' \
+lint:
+	golangci-lint run ./...
+	actionlint
+	find . -type f -name '*.sh' \
 		-not -path './.git/*' \
 		-not -path './.local/*' \
 	| while IFS= read -r file; do shellcheck "$${file}"; done
+	go mod tidy
+	git diff --exit-code go.mod go.sum
+	govulncheck ./...
 
-.PHONY: docs
-docs: tools install
-	@echo "Generating Docs..."
-	@$(BIN)/./tfplugindocs generate -rendered-provider-name "GitHub" >/dev/null
+docs: install
+	tfplugindocs generate -rendered-provider-name "GitHub" >/dev/null
 
-.PHONY: test
-test: $(BIN)/go
-	@echo "Testing..."
-	@go test ./... -count=1
+test:
+	go test -race -count=1 ./...
 
-.PHONY: testacc
 testacc: install
-	@echo "Testing Acceptance..."
-	@cd internal/provider && TF_ACC=1 go test -count=1 -v
+	cd internal/provider && TF_ACC=1 go test -count=1 -v
 
-.PHONY: clean
+update:
+	go get -u
+	go mod tidy
+
 clean:
-	@echo "Removing the $(CACHE) directory..."
-	@go clean -modcache
-	@rm -rf $(CACHE)
-	@echo "Removing the $(BIN) directory..."
-	@rm -rf $(BIN)
-	@echo "Removing the $(PWD)/.local directory..."
-	@if [ -d "$(PWD)/.local" ]; then rmdir "$(PWD)/.local"; fi
+	rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ lint:
 	go mod tidy
 	git diff --exit-code go.mod go.sum
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) validate
 
 docs: install
 	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TFPLUGINDOCS_VERSION) generate \

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: ""
 page_title: "GitHub Provider"
 description: |-
   The GitHub provider provides resources to interact with the GitHub API.

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -112,6 +112,8 @@ resource "github_repository" "example" {
 ## Import
 
 ```shell
+#!/bin/sh
+
 # Repositories can be imported using the numerical
 # GitHub ID of the repository.
 terraform import github_repository.test 123456789

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/craigsloggett/terraform-provider-github
 
-go 1.26.1
+go 1.26.0
 
 require (
 	github.com/google/go-github/v84 v84.0.0
@@ -16,7 +16,7 @@ require (
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
-	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/color v1.19.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
@@ -60,7 +60,7 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/craigsloggett/terraform-provider-github
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/google/go-github/v84 v84.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
-github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
@@ -235,10 +235,10 @@ gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c h1:xgCzyF2LFIO/0X2UAoVRiXKU5Xg6VjToG4i2/ecSswk=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 h1:ndE4FoJqsIceKP2oYSnUZqhTdYufCYYkqwtFzfrhI7w=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,5 +1,4 @@
 ---
-layout: ""
 page_title: "GitHub Provider"
 description: |-
   The GitHub provider provides resources to interact with the GitHub API.


### PR DESCRIPTION
- Sync Makefile conventions from template repo: use `go run` for tooling, add `yamllint` to lint, simplify `install` and `clean` targets
- Pin golangci-lint, govulncheck, and tfplugindocs versions in Makefile and CI for reproducible builds
- Add tfplugindocs `validate` to Makefile lint and `validate` + `generate` drift check to CI
- Repurpose Update workflow to track golangci-lint, govulncheck, tfplugindocs, and Terraform versions via a matrix job (replaces Go version bumping)
- Remove redundant `cache: true` from all `actions/setup-go` steps (default since v4)
- Add concurrency groups, permissions, and timeout-minutes to all workflows
- Replace inline tool installation with composite actions for actionlint and yamllint
- Replace semantic-release with `craigsloggett/create-github-release`; trigger release on Test workflow success
- Add Test workflow with race detection
- Add `go mod tidy` and `govulncheck` CI jobs
- Add missing `.gitignore` patterns: coverage files, `go.work.sum`, `.env`
- Align `.golangci.yml` with template: add bodyclose, errorlint, gosec, goimports
- Align `.yamllint.yml`: enable `indent-sequences`, set `line-length` max to 120
- Fix deprecated `layout` frontmatter in docs template and generated index
- Update indirect dependencies (fatih/color, grpc, genproto)