### PR TITLE
chore(deps): Update golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.3
+          version: v2.11.4
 
   tidy:
     name: Go Mod Tidy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROVIDER_NAME         := terraform-provider-github
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
-GOLANGCI_LINT_VERSION := v2.11.3
+GOLANGCI_LINT_VERSION := v2.11.4
 GOVULNCHECK_VERSION   := v1.1.4
 TFPLUGINDOCS_VERSION  := v0.24.0
 


### PR DESCRIPTION
Update golangci-lint to v2.11.4 (workflow: v2.11.3, Makefile: v2.11.3).