### PR TITLE
chore(build): Bump Terraform to 1.15.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.15.3
+          terraform_version: 1.15.4
 
       - name: Lint Terraform Files
         run: |


### PR DESCRIPTION
Bump the pinned Terraform version used by the `terraform-fmt` job in `lint.yml`.

*Generated by the scheduled `update.yml` workflow.*
