### PR TITLE
chore(ci): Pull job summary out of composite action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,6 +32,16 @@ jobs:
           file: .github/workflows/lint.yml
           path: .jobs.terraform-fmt.steps[1].with.terraform_version
 
+      - name: Emit Job Summary
+        if: steps.bump-terraform.outputs.changed == 'true'
+        run: |
+          {
+            printf -- '### Updates Available\n\n'
+            printf -- '- `terraform` can be updated in `%s` to `v%s`\n\n' \
+              "${{ steps.bump-terraform.outputs.file }}" \
+              "${{ steps.bump-terraform.outputs.version }}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
       - name: Create GitHub Pull Request
         if: steps.bump-terraform.outputs.changed == 'true'
         uses: craigsloggett/create-github-pull-request@a5692a4051cd824b5367f022d35bba64e280f41b # v1.0.1

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,16 +25,17 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Bump Terraform
+      - name: Update Lint Workflow
         id: bump-terraform
-        uses: craigsloggett/bump-terraform-cli@949a01969e7b7b8a1c84797a5cddff7194080ce3 # v1.0.2
+        uses: craigsloggett/bump-terraform-cli@a76db06580101f05a1233963f43ba1ba4b8bf5a0 # v1.0.3
         with:
           file: .github/workflows/lint.yml
           path: .jobs.terraform-fmt.steps[1].with.terraform_version
 
-      - name: Emit Job Summary
+      - name: Publish Available Updates in Step Summary
         if: steps.bump-terraform.outputs.changed == 'true'
         run: |
+          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
           {
             printf -- '### Updates Available\n\n'
             printf -- '- `terraform` can be updated in `%s` to `v%s`\n\n' \


### PR DESCRIPTION
The upstream composite action removes the Markdown summary being emitted and I am pulling it into the workflow in this consuming repository.