### PR TITLE
fix: Bump Go to 1.26.4 to patch stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/craigsloggett/terraform-provider-github
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-github/v84 v84.0.0


### PR DESCRIPTION
- Bumps the `go` directive in `go.mod` from `1.26.3` to `1.26.4`, the lowest release without the currently known stdlib vulnerabilities.
- Resolves the two govulncheck findings reachable from the provider: `GO-2026-5037` (crypto/x509) and `GO-2026-5039` (net/textproto), both fixed in go1.26.4.