### PR TITLE
ci: Drive update summary from bump-version file list

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,8 +18,11 @@ jobs:
   terraform:
     name: terraform
     runs-on: ubuntu-24.04
+    env:
+      TOOL: terraform
     steps:
-      - name: Checkout
+      - &checkout
+        name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_TOKEN }}
@@ -36,7 +39,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -52,23 +55,26 @@ jobs:
         with:
           title: 'chore(ci): Bump terraform to ${{ steps.latest.outputs.version }}'
           body: >-
-            Bump the pinned `terraform` version in `lint.yml` to
-            `${{ steps.latest.outputs.version }}`
+            Bump the pinned `terraform` version in
+            `${{ steps.bump-lint.outputs.file }}` to `${{ steps.latest.outputs.version }}`
           branch: update/bump-terraform-${{ steps.latest.outputs.version }}
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Publish Available Updates in Step Summary
         if: steps.bump-lint.outputs.changed == 'true'
-        run: |
+        run: &updates_summary_run |
+          summary="${RUNNER_TEMP}/changed-files.md"
+          [ -s "${summary}" ] || exit 0
           # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
           {
             printf -- '### Updates Available\n\n'
-            printf -- '- `terraform` can be updated in `%s` to `v%s`\n\n' \
-              '.github/workflows/lint.yml' \
-              "${{ steps.latest.outputs.version }}"
+            printf -- '`%s` can be updated to `%s` in:\n\n' \
+              "${TOOL}" "${{ steps.latest.outputs.version }}"
+            cat "${summary}"
           } >>"${GITHUB_STEP_SUMMARY}"
 
-      - name: Publish Pull Request Details in Step Summary
+      - &pr_summary
+        name: Publish Pull Request Details in Step Summary
         if: steps.create-github-pull-request.conclusion == 'success'
         run: |
           # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
@@ -85,11 +91,10 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-24.04
+    env:
+      TOOL: govulncheck
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.GH_TOKEN }}
+      - *checkout
 
       - name: Resolve Latest Version
         id: latest
@@ -103,7 +108,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -114,7 +119,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: Makefile
           key: GOVULNCHECK_VERSION
@@ -129,7 +134,8 @@ jobs:
         with:
           title: 'chore(build): Bump govulncheck to ${{ steps.latest.outputs.version }}'
           body: >-
-            Bump the pinned `govulncheck` version in `lint.yml` and `Makefile` to
+            Bump the pinned `govulncheck` version in
+            `${{ steps.bump-lint.outputs.file }}` and `${{ steps.bump-makefile.outputs.file }}` to
             `${{ steps.latest.outputs.version }}`
           branch: update/bump-govulncheck-${{ steps.latest.outputs.version }}
           token: ${{ secrets.GH_TOKEN }}
@@ -138,38 +144,17 @@ jobs:
         if: >-
           steps.bump-lint.outputs.changed == 'true' ||
           steps.bump-makefile.outputs.changed == 'true'
-        run: |
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Updates Available\n\n'
-            printf -- '- `govulncheck` can be updated in `%s` and `%s` to `%s`\n\n' \
-              '.github/workflows/lint.yml' \
-              'Makefile' \
-              "${{ steps.latest.outputs.version }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+        run: *updates_summary_run
 
-      - name: Publish Pull Request Details in Step Summary
-        if: steps.create-github-pull-request.conclusion == 'success'
-        run: |
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Pull Request Created\n\n'
-            printf -- '- URL: %s\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Files changed: %s/files\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Checks: %s/checks\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+      - *pr_summary
 
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-24.04
+    env:
+      TOOL: golangci-lint
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.GH_TOKEN }}
+      - *checkout
 
       - name: Resolve Latest Version
         id: latest
@@ -183,7 +168,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -194,7 +179,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: Makefile
           key: GOLANGCI_LINT_VERSION
@@ -209,7 +194,8 @@ jobs:
         with:
           title: 'chore(build): Bump golangci-lint to ${{ steps.latest.outputs.version }}'
           body: >-
-            Bump the pinned `golangci-lint` version in `lint.yml` and `Makefile` to
+            Bump the pinned `golangci-lint` version in
+            `${{ steps.bump-lint.outputs.file }}` and `${{ steps.bump-makefile.outputs.file }}` to
             `${{ steps.latest.outputs.version }}`
           branch: update/bump-golangci-lint-${{ steps.latest.outputs.version }}
           token: ${{ secrets.GH_TOKEN }}
@@ -218,38 +204,17 @@ jobs:
         if: >-
           steps.bump-lint.outputs.changed == 'true' ||
           steps.bump-makefile.outputs.changed == 'true'
-        run: |
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Updates Available\n\n'
-            printf -- '- `golangci-lint` can be updated in `%s` and `%s` to `%s`\n\n' \
-              '.github/workflows/lint.yml' \
-              'Makefile' \
-              "${{ steps.latest.outputs.version }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+        run: *updates_summary_run
 
-      - name: Publish Pull Request Details in Step Summary
-        if: steps.create-github-pull-request.conclusion == 'success'
-        run: |
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Pull Request Created\n\n'
-            printf -- '- URL: %s\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Files changed: %s/files\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Checks: %s/checks\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+      - *pr_summary
 
   tfplugindocs:
     name: tfplugindocs
     runs-on: ubuntu-24.04
+    env:
+      TOOL: tfplugindocs
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ secrets.GH_TOKEN }}
+      - *checkout
 
       - name: Resolve Latest Version
         id: latest
@@ -263,7 +228,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -274,7 +239,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@525c115c3ffc057b3eee126e83e223b600b62125 # v1.0.0
+        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
         with:
           file: Makefile
           key: TFPLUGINDOCS_VERSION
@@ -289,7 +254,8 @@ jobs:
         with:
           title: 'chore(build): Bump tfplugindocs to ${{ steps.latest.outputs.version }}'
           body: >-
-            Bump the pinned `tfplugindocs` version in `lint.yml` and `Makefile` to
+            Bump the pinned `tfplugindocs` version in
+            `${{ steps.bump-lint.outputs.file }}` and `${{ steps.bump-makefile.outputs.file }}` to
             `${{ steps.latest.outputs.version }}`
           branch: update/bump-tfplugindocs-${{ steps.latest.outputs.version }}
           token: ${{ secrets.GH_TOKEN }}
@@ -298,26 +264,6 @@ jobs:
         if: >-
           steps.bump-lint.outputs.changed == 'true' ||
           steps.bump-makefile.outputs.changed == 'true'
-        run: |
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Updates Available\n\n'
-            printf -- '- `tfplugindocs` can be updated in `%s` and `%s` to `%s`\n\n' \
-              '.github/workflows/lint.yml' \
-              'Makefile' \
-              "${{ steps.latest.outputs.version }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+        run: *updates_summary_run
 
-      - name: Publish Pull Request Details in Step Summary
-        if: steps.create-github-pull-request.conclusion == 'success'
-        run: |-
-          # shellcheck disable=SC2016 # Backticks here are literal Markdown code-spans.
-          {
-            printf -- '### Pull Request Created\n\n'
-            printf -- '- URL: %s\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Files changed: %s/files\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-            printf -- '- Checks: %s/checks\n' \
-              "${{ steps.create-github-pull-request.outputs.url }}"
-          } >>"${GITHUB_STEP_SUMMARY}"
+      - *pr_summary

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,8 +21,7 @@ jobs:
     env:
       TOOL: terraform
     steps:
-      - &checkout
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_TOKEN }}
@@ -94,7 +93,10 @@ jobs:
     env:
       TOOL: govulncheck
     steps:
-      - *checkout
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Resolve Latest Version
         id: latest
@@ -154,7 +156,10 @@ jobs:
     env:
       TOOL: golangci-lint
     steps:
-      - *checkout
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Resolve Latest Version
         id: latest
@@ -214,7 +219,10 @@ jobs:
     env:
       TOOL: tfplugindocs
     steps:
-      - *checkout
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Resolve Latest Version
         id: latest

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -108,7 +108,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -119,7 +119,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: Makefile
           key: GOVULNCHECK_VERSION
@@ -168,7 +168,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -179,7 +179,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: Makefile
           key: GOLANGCI_LINT_VERSION
@@ -228,7 +228,7 @@ jobs:
 
       - name: Bump Lint Workflow
         id: bump-lint
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: .github/workflows/lint.yml
           key: >-
@@ -239,7 +239,7 @@ jobs:
 
       - name: Bump Makefile
         id: bump-makefile
-        uses: craigsloggett/bump-version@23e0bae635cfe548240afdf2b010cea8db248360 # v1.1.0
+        uses: craigsloggett/bump-version@85e673033cf965281d41ec89c94189a335fa7633 # v1.1.1
         with:
           file: Makefile
           key: TFPLUGINDOCS_VERSION


### PR DESCRIPTION
- Re-pin `craigsloggett/bump-version` to v1.1.0, which adds a `file` output and appends each changed file to a job-scoped `${RUNNER_TEMP}/changed-files.md`.
- The Available Updates summary now `cat`s that list instead of hard-coding `lint.yml`/`Makefile`, so it reports exactly what changed and cannot drift from the bump targets.
- Share Checkout, the summary body, and the PR-details step across the four jobs via YAML anchors; carry the per-tool name in a job-level `env: TOOL`.