### PR TITLE
chore(ci): Bump terraform to 1.15.7

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.15.6
+          terraform_version: 1.15.7
 
       - name: Lint Terraform Files
         run: |


### PR DESCRIPTION
Bump the pinned `terraform` version to `1.15.7` in:

- `.github/workflows/lint.yml`