### PR TITLE
chore(build): Bump govulncheck to v1.6.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install govulncheck
         env:
-          GOVULNCHECK_VERSION: v1.4.0
+          GOVULNCHECK_VERSION: v1.6.0
         run: go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 
       - name: Run govulncheck

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROVIDER_NAME         := terraform-provider-github
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 GOLANGCI_LINT_VERSION := v2.12.2
-GOVULNCHECK_VERSION   := v1.4.0
+GOVULNCHECK_VERSION   := v1.6.0
 TFPLUGINDOCS_VERSION  := v0.25.0
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod)
 


### PR DESCRIPTION
Bump the pinned `govulncheck` version to `v1.6.0` in:

- `.github/workflows/lint.yml`
- `Makefile`