### PR TITLE
chore(build): Bump golangci-lint to v2.13.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.1
 
   tidy:
     name: Go Mod Tidy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROVIDER_NAME         := terraform-provider-github
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
-GOLANGCI_LINT_VERSION := v2.12.2
+GOLANGCI_LINT_VERSION := v2.13.1
 GOVULNCHECK_VERSION   := v1.7.0
 TFPLUGINDOCS_VERSION  := v0.25.0
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod)


### PR DESCRIPTION
Bump the pinned `golangci-lint` version to `v2.13.1` in:

- `.github/workflows/lint.yml`
- `Makefile`